### PR TITLE
Fix minor documentation typos and style issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,7 +119,7 @@ How to Improve TinyDB Performance
 `````````````````````````````````
 
 The default storage serializes the data using JSON. To improve performance,
-you can install `ujson <http://pypi.python.org/pypi/ujson>`_ , a extremely
+you can install `ujson <http://pypi.python.org/pypi/ujson>`_ , an extremely
 fast JSON implementation. TinyDB will auto-detect and use it if possible.
 
 In addition, you can wrap the storage with the ``CachingMiddleware`` which

--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -42,7 +42,7 @@ To write a custom storage, subclass :class:`~tinydb.middlewares.Middleware`:
 
         To access the underlying storage's
         read method, use
-        :func:`self.stroage.read <tinydb.storages.Storage.read>`.
+        :func:`self.storage.read <tinydb.storages.Storage.read>`.
 
     .. function:: write(self, data)
 
@@ -50,7 +50,7 @@ To write a custom storage, subclass :class:`~tinydb.middlewares.Middleware`:
 
         To access the underlying storage's
         read method, use
-        :func:`self.stroage.read <tinydb.storages.Storage.write>`.
+        :func:`self.storage.read <tinydb.storages.Storage.write>`.
 
 To use your middleware, use:
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -40,7 +40,7 @@ TinyDB has been tested with Python 2.6, 2.7, 3.2, 3.3 and pypy.
 Why **not** using TinyDB?
 -----------------------------
 
-- You need **advanced features** like multiple indexes, a HTTP server,
+- You need **advanced features** like multiple indexes, an HTTP server,
   relationships, or similar.
 - You are really concerned about **high performance** and need a high speed
   database.

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -8,15 +8,15 @@ TinyDB serializes all data using the
 `Python JSON <http://docs.python.org/2/library/json.html>`_ module by default.
 It serializes most basic Python data types very well, but fails serializing
 classes and stores ``tuple`` as ``list``. If you need a better
-serializer, you can write your own storage, that e.g. uses the more powerfull
+serializer, you can write your own storage, that e.g. uses the more powerful
 (but also slower) `pickle  <http://docs.python.org/library/pickle.html>`_ or
 `PyYAML  <http://pyyaml.org/>`_.
 
 Performance
 ^^^^^^^^^^^
 
-TinyDB is NOT designed to be used in environments, where performance might be
-an issue. Altough you can improve the TinyDB performance as described below,
+TinyDB is NOT designed to be used in environments where performance might be
+an issue. Although you can improve the TinyDB performance as described below,
 you should consider using a DB that is optimized for speed like Buzhug_ or
 CodernityDB_.
 
@@ -24,7 +24,7 @@ How to Improve TinyDB Performance
 `````````````````````````````````````
 
 The default storage serializes the data using JSON. To improve performance, you
-can install `ujson <http://pypi.python.org/pypi/ujson>`_ , a extremely fast
+can install `ujson <http://pypi.python.org/pypi/ujson>`_ , an extremely fast
 JSON implementation. TinyDB will auto-detect and use it if possible.
 
 In addition, you can wrap the storage with the

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -60,7 +60,7 @@ Getting the database size (number of elements stored):
 3
 
 
-Search for all elements, that have the ``value`` key defined:
+Search for all elements that have the ``value`` key defined:
 
 >>> db.search(where('value'))
 [{'int': 1, 'value': 5.0}]
@@ -185,7 +185,7 @@ TinyDB ships with these middlewares:
   read operations and writes data to disk every
   ``CachingMiddleware.WRITE_CACHE_SIZE`` write operations.
 - **ConcurrencyMiddleware**: Allows you to use TinyDB in multithreaded
-  environments by using a lock on read and write operations making
+  environments by using a lock on read and write operations, making
   them virtually atomic.
 
 .. hint::

--- a/tinydb/queries.py
+++ b/tinydb/queries.py
@@ -84,7 +84,7 @@ class Query(AndOrMixin):
 
     def test(self, func):
         """
-        Run an user defined test function against a dict value.
+        Run a user-defined test function against a dict value.
 
         >>> def test_func(val):
         ...     return val == 42
@@ -316,7 +316,7 @@ class QueryRegex(AndOrMixin):
 
 class QueryCustom(AndOrMixin):
     """
-    Run an user defined test function against a dict value.
+    Run a user-defined test function against a dict value.
 
     See :meth:`Query.test`.
     """


### PR DESCRIPTION
This fixes a few minor documentation typos and style issues, e.g., "a"
vs. "an", comma usage, and the like.
