### PR TITLE
Add support for nested comparisons

### DIFF
--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -113,18 +113,18 @@ def test_nested_query():
     assert not query({})
 
 
-def test_each_query():
-    query = where('user').any('followers') == 'don'
+def test_any_query():
+    query = where('user.followers').any(where('name') == 'don')
 
-    assert query({'user':{'followers':['john', 'don']}})
+    assert query({'user': {'followers': [{'name': 'don'}, {'name': 'john'}]}})
     assert not query({'user':{'followers':1}})
     assert not query({})
 
-    query = ~query
-    assert query({})
+    query = where('user.followers').any(where('num').matches('\\d+'))
+    assert query({'user': {'followers': [{'num': '12'}]}})
 
-    query = where('user').any('followers').matches('\\d+')
-    assert query({'user':{'followers':['12']}})
 
-    query = where('user').any('followers').test(lambda x:x)
-    assert query({'user':{'followers':[0,1,0]}})
+def test_each_query():
+    query = where('user.followers').each(where('name') == 'don')
+    assert not query({'user': {'followers': [{'name': 'don'}, {'name': 'john'}]}})
+    assert query({'user': {'followers': [{'name':'don'}]}})


### PR DESCRIPTION
Added support for nested comparisons in the `where` object, and simplified the codebase drastically. Nested comparisons was inspired by [this](https://github.com/msiemens/tinydb/issues/10) issue. As proposed in the issue the syntax is:

``` python
query = where('user.name') == 'John'
assert query({'user': {'name': 'John'}})
```

Also new `any` and `each` functions were added to serve for querying of iterables. For example:

``` python
user = {'user': {'pets': [{'name': 'cat'}, {'name': 'dog'}]}}
any_query = where('user.pets').any(where('name') == 'dog')
each_query = where('user.pets').each(where('name') == 'dog')

assert any_query(user)
assert not each_query(user)
```
