### PR TITLE
Added LRU cache

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -81,3 +81,6 @@ def test_lru_cache(db):
     table.search(where('int') == 2)
     table.search(where('int') == 3)
     assert query not in table._queries_cache
+
+    table.remove(where('int') == 1)
+    assert not table._lru

--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -378,6 +378,7 @@ class Table(object):
         Clear query cache.
         """
         self._queries_cache = {}
+        self._lru = []
 
     def __enter__(self):
         """


### PR DESCRIPTION
Now queries are not popped at random from the cache but the least recently used is popped instead. This not only saves the database calculation time for frequently used queries but also makes sure that the less frequently used objects are freed. I.e.

``` python
table = db.table('table3', cache_size=1)
query = where('key') == 2

table.search(query)
table.search(where('key') == 1)

assert query not in table._queries_cache
```
