### PR TITLE
added __getitem__ method

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -95,3 +95,15 @@ def test_lru_cache(db):
 
     table.remove(where('int') == 1)
     assert not table._query_cache.lru
+
+
+def test_getitem(db):
+    table = db.table('table3')
+    table.insert({'int': 1})
+    table.insert({'int': 2})
+    table.insert({'int': 3})
+
+    assert table[0] == {'int': 1}
+    assert table[:2] == [{'int': 1}, {'int': 2}]
+    assert table[1:] == [{'int': 2}, {'int': 3}]
+    assert table[1:2:2] == [{'int': 2}]

--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -160,6 +160,9 @@ class TinyDB(object):
         """
         return self._table.__exit__(*args)
 
+    def __getitem__(self, sl):
+        return self._table[sl]
+
     def __getattr__(self, name):
         """
         Forward all unknown attribute calls to the underlying standard table.
@@ -438,6 +441,9 @@ class Table(object):
         self._db._storage.close()
 
     close = __exit__
+
+    def __getitem__(self, sl):
+        return self.all()[sl]
 
 
 class SmartCacheTable(Table):


### PR DESCRIPTION
Allows you to slice the tables:

``` python
table.insert_multiple([{'int': k} for k in range(1, 3)])

assert table[0] == [{'int': 1}]
assert table[1:2] == [{'int': 2}]
```
