### PR TITLE
Fix decode error of README.rst during installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from setuptools import setup, find_packages
+from codecs import open
 
 setup(
     name="tinydb",
@@ -33,5 +34,5 @@ setup(
         "Operating System :: OS Independent"
     ],
 
-    long_description=open('README.rst', 'r').read(),
+    long_description=open('README.rst', encoding='utf-8').read(),
 )


### PR DESCRIPTION
Fix decode error in environment that default encoding is not utf-8.

Error log:

```
Traceback (most recent call last):
  File "<string>", line 17, in <module>
  File "C:\Users\Asvel\AppData\Local\Temp\pip_build_Asvel\tinydb\setup.py", line 36, in <module>
    long_description=open('README.rst', 'r').read(),
UnicodeDecodeError: 'gbk' codec can't decode byte 0x93 in position 1037: illegal multibyte sequence
```
