### PR TITLE
Create infrastructure for custom table classes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from tinydb.database import SmartCacheTable
 
 from tinydb.middlewares import CachingMiddleware
 from tinydb.storages import MemoryStorage
@@ -10,7 +11,8 @@ def get_db(smart_cache=False):
     db_.purge_tables()
 
     if smart_cache:
-        db_ = db_.table('_default', smart_cache=True)
+        db_.table_class = SmartCacheTable
+        db_ = db_.table('_default')
 
     db_.insert_multiple({'int': 1, 'char': c} for c in 'abc')
     return db_

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1,4 +1,8 @@
-from tinydb import where
+from warnings import catch_warnings
+import pytest
+from tinydb.utils import catch_warning
+from tinydb import where, TinyDB
+from tinydb.database import SmartCacheTable, Table
 
 
 def test_tables_list(db):
@@ -57,7 +61,8 @@ def test_query_cache_size(db):
 
 
 def test_smart_query_cache(db):
-    table = db.table('table3', smart_cache=True)
+    db.table_class = SmartCacheTable
+    table = db.table('table3')
     query = where('int') == 1
     dummy = where('int') == 2
 
@@ -81,6 +86,29 @@ def test_smart_query_cache(db):
     table.remove(where('int') == 1)
 
     assert table.count(where('int') == 1) == 0
+
+
+def test_smart_query_cache_via_kwarg(db):
+    # For backwards compatibility
+    with pytest.raises(DeprecationWarning):
+        with catch_warning(DeprecationWarning):
+            table = db.table('table3', smart_cache=True)
+            assert isinstance(table, SmartCacheTable)
+
+
+def test_custom_table_class_via_class_attribute(db):
+    TinyDB.table_class = SmartCacheTable
+
+    table = db.table('table3')
+    assert isinstance(table, SmartCacheTable)
+
+    TinyDB.table_class = Table
+
+
+def test_custom_table_class_via_instance_attribute(db):
+    db.table_class = SmartCacheTable
+    table = db.table('table3')
+    assert isinstance(table, SmartCacheTable)
 
 
 def test_lru_cache(db):

--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -5,9 +5,14 @@ import sys
 from . conftest import get_db
 
 from tinydb import TinyDB, where
+from tinydb.database import Table, SmartCacheTable
 from tinydb.storages import MemoryStorage
 
-dbs = lambda: [get_db(), get_db(smart_cache=True)]
+def dbs():
+    yield get_db()
+    yield get_db(smart_cache=True)
+
+# dbs = lambda: [get_db(), get_db(smart_cache=True)]
 
 
 @pytest.mark.parametrize('db', dbs())

--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -2,6 +2,7 @@
 Contains the :class:`database <tinydb.database.TinyDB>` and
 :class:`tables <tinydb.database.Table>` implementation.
 """
+import warnings
 from tinydb import JSONStorage
 from tinydb.utils import LRUCache
 
@@ -63,7 +64,16 @@ class TinyDB(object):
         if name in self._table_cache:
             return self._table_cache[name]
 
-        table_class = SmartCacheTable if smart_cache else Table
+        if smart_cache:
+            warnings.warn('Passing the smart_cache argument is deprecated. '
+                          'Please set the table class to use via '
+                          '`db.table_class = SmartCacheTable` or '
+                          '`TinyDB.table_class = SmartCacheTable` instead.',
+                          DeprecationWarning)
+
+        # If smart_cache is set, use SmartCacheTable to retain backwards
+        # compatibility
+        table_class = SmartCacheTable if smart_cache else self.table_class
         table = table_class(name, self, **options)
 
         self._table_cache[name] = table
@@ -511,3 +521,7 @@ class SmartCacheTable(Table):
 
         super(SmartCacheTable, self).purge()
         self._query_cache.clear()  # Query cache got invalid
+
+
+# Set the default table class
+TinyDB.table_class = Table


### PR DESCRIPTION
Now one can set which table class TinyDB should use by setting the `table_class` attribute on the TinyDB class or instance. This gives us the flexibility to introduce more powerful features in custom table classes without flooding `TinyDB.__init__` and `TinyDB.table` with additional special arguments.

This also deprecates the `smart_cache` argument of `TinyDB.__init__` and `TinyDB.table` in favor of this feature.

Example:

``` python
TinyDB.table_class = SmartCacheTable  # For all new instances
# or
db.table_class = SmartCacheTable  # For all new tables
```
