### PR TITLE
Add support for custom serializers

### DIFF
--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -22,12 +22,17 @@ for ``datetime`` objects could look like:
         def decode(self, s):
             return datetime.strptime(s, '%Y-%m-%dT%H:%M:%S')
 
-We can use this Serializer like this:
+To use the new serializer, we need to use the serialization middleware:
 
 .. code-block:: python
 
-    >>> db = TinyDB('db.json')
-    >>> db.register_serializer(DateTimeSerializer(), 'TinyDate')
+    >>> from tinydb.storages import JSONStorage
+    >>> from tinydb.middlewares import SerializationMiddleware
+    >>>
+    >>> serialization = SerializationMiddleware()
+    >>> serialization.register_serializer(DateTimeSerializer(), 'TinyDate')
+    >>>
+    >>> db = TinyDB('db.json', storage=serialization)
     >>> db.insert({'date': datetime(2000, 1, 1, 12, 0, 0)})
     >>> db.all()
     [{'date': datetime.datetime(2000, 1, 1, 12, 0)}]

--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -1,6 +1,38 @@
 How to Extend TinyDB
 ====================
 
+Write a Serializer
+------------------
+
+TinyDB's default storage is fairly limited when it comes to supported data types.
+If you need more flexibility, you can implement a Serializer. This allows TinyDB
+to handle classes it otherwise couldn't serialize. Let's see how a Serializer
+for ``datetime`` objects could look like:
+
+.. code-block:: python
+
+    from datetime import datetime
+
+    class DateTimeSerializer(Serializer):
+        NAME = 'TinyDate'  # A unique name
+        OBJ_CLASS = datetime  # The class this serializer handles
+
+        def encode(self, obj):
+            return obj.strftime('%Y-%m-%dT%H:%M:%S')
+
+        def decode(self, s):
+            return datetime.strptime(s, '%Y-%m-%dT%H:%M:%S')
+
+We can use this Serializer like this:
+
+.. code-block:: python
+
+    >>> db = TinyDB('db.json')
+    >>> db.register_serializer(DateTimeSerializer())
+    >>> db.insert({'date': datetime(2000, 1, 1, 12, 0, 0)})
+    >>> db.all()
+    [{'date': datetime.datetime(2000, 1, 1, 12, 0)}]
+
 Write a custom Storage
 ----------------------
 

--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -14,7 +14,6 @@ for ``datetime`` objects could look like:
     from datetime import datetime
 
     class DateTimeSerializer(Serializer):
-        NAME = 'TinyDate'  # A unique name
         OBJ_CLASS = datetime  # The class this serializer handles
 
         def encode(self, obj):
@@ -28,7 +27,7 @@ We can use this Serializer like this:
 .. code-block:: python
 
     >>> db = TinyDB('db.json')
-    >>> db.register_serializer(DateTimeSerializer())
+    >>> db.register_serializer(DateTimeSerializer(), 'TinyDate')
     >>> db.insert({'date': datetime(2000, 1, 1, 12, 0, 0)})
     >>> db.all()
     [{'date': datetime.datetime(2000, 1, 1, 12, 0)}]

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -427,8 +427,9 @@ What's next
 Congratulations, you've made through the user guide! Now go and build something
 awesome or dive deeper into TinyDB with these ressources:
 
-- Want to learn how to customize TinyDB and what extensions exist?
-  Check out :doc:`extend`.
+- Want to learn how to customize TinyDB (custom serializers, storages,
+  middlewares) and what extensions exist? Check out :doc:`extend` and
+  :doc:`extensions`.
 - Want to study the API in detail? Read :doc:`api`.
 - Interested in contributing to the TinyDB development guide? Go on to the
   :doc:`contribute`.

--- a/tinydb/utils.py
+++ b/tinydb/utils.py
@@ -103,3 +103,19 @@ def catch_warning(warning_cls):
         warnings.filterwarnings('error', category=warning_cls)
 
         yield
+
+
+class AbstractAttribute(object):
+    """An abstract class attribute.
+
+    Use this instead of an abstract property when you don't expect the
+    attribute to be implemented by a property.
+    """
+
+    __isabstractmethod__ = True
+
+    def __init__(self, doc=""):
+        self.__doc__ = doc
+
+    def __get__(self, obj, cls):
+        return self


### PR DESCRIPTION
As discussed in #48, it would be nice to have support for custom serialization of objects unknown to TinyDB (= not supported by the JSON backend). This implements this interface, but I'm unsure how useful it will be.

cc @eugene-eeo @EmilStenstrom