### PR TITLE
If there is no modified data, do not write.

### DIFF
--- a/tinydb/middlewares.py
+++ b/tinydb/middlewares.py
@@ -111,9 +111,9 @@ class CachingMiddleware(Middleware):
         """
         Flush all unwritten data to disk.
         """
-
-        self.storage.write(self.cache)
-        self._cache_modified_count = 0
+        if self._cache_modified_count > 0:
+            self.storage.write(self.cache)
+            self._cache_modified_count = 0
 
     def close(self):
         self.flush()


### PR DESCRIPTION
This avoids an exception:

    Exception ValueError: 'I/O operation on closed file' in <bound method CachingMiddleware.__del__ of  <tinydb.middlewares.CachingMiddleware object at 0x7f9c96610a90>> ignored

The case happens when the objects has been closed and __del__ is invoked. Since the semantics guarantees
no writes after close, avoid storage.write when there are no changes in flush seems to be a reasonable fix.