### PR TITLE
Allow users to specify additional arguments for the JSON storage

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -384,6 +384,13 @@ To use the in-memory storage, use:
 >>> from tinydb.storages import MemoryStorage
 >>> db = TinyDB(storage=MemoryStorage)
 
+.. hint::
+    All arguments except for the ``storage`` argument are forwarded to the
+    underlying storage. For the JSON storage you can use this to pass
+    additional keyword arguments to Python's
+    `json.dump(...) <https://docs.python.org/2/library/json.html#json.dump>`_
+    method.
+
 Middlewares
 ...........
 

--- a/tests/test_storages.py
+++ b/tests/test_storages.py
@@ -24,6 +24,26 @@ def test_json(tmpdir):
     assert element == storage.read()
 
 
+def test_json_kwargs(tmpdir):
+    db_file = tmpdir.join('test.db')
+    db = TinyDB(str(db_file), sort_keys=True, indent=4, separators=(',', ': '))
+
+    # Write contents
+    db.insert({'b': 1})
+    db.insert({'a': 1})
+
+    assert db_file.read() == '''{
+    "_default": {
+        "1": {
+            "b": 1
+        },
+        "2": {
+            "a": 1
+        }
+    }
+}'''
+
+
 def test_json_readwrite(tmpdir):
     """
     Regression test for issue #1

--- a/tinydb/storages.py
+++ b/tinydb/storages.py
@@ -70,7 +70,7 @@ class JSONStorage(Storage):
     Store the data in a JSON file.
     """
 
-    def __init__(self, path):
+    def __init__(self, path, **kwargs):
         """
         Create a new instance.
 
@@ -83,6 +83,7 @@ class JSONStorage(Storage):
         super(JSONStorage, self).__init__()
         touch(path)  # Create file if not exists
         self.path = path
+        self.kwargs = kwargs
         self._handle = open(path, 'r+')
 
     def close(self):
@@ -97,7 +98,7 @@ class JSONStorage(Storage):
 
     def write(self, data):
         self._handle.seek(0)
-        json.dump(data, self._handle)
+        json.dump(data, self._handle, **self.kwargs)
         self._handle.flush()
         self._handle.truncate()
 


### PR DESCRIPTION
Alternative implementation for #60. Example usage:

```
db = TinyDB('db.json', sort_keys=True, indent=4, separators=(',', ': '))
```