### PR TITLE
Fix exception AttributeError

### DIFF
--- a/tinydb/storages.py
+++ b/tinydb/storages.py
@@ -87,7 +87,8 @@ class JSONStorage(Storage):
         self._handle = open(path, 'r+')
 
     def close(self):
-        self._handle.close()
+        if hasattr(self, '_handle'):
+            self._handle.close()
 
     def __del__(self):
         self.close()


### PR DESCRIPTION
Bug can be reproduced with the following snippet:

```
from tinydb import TinyDB, where
try:
    db = TinyDB("/does/not/exist/db.json")
except FileNotFoundError:
    # do something else
    pass
```

Results in: 
```
Exception ignored in: <bound method JSONStorage.__del__ of <tinydb.storages.JSONStorage object at 0x7f0b27a7ea90>>
Traceback (most recent call last):
  File "python/lib/python3.4/site-packages/tinydb/storages.py", line 94, in __del__
    self.close()
  File "python/lib/python3.4/site-packages/tinydb/storages.py", line 91, in close

    self._handle.close()
AttributeError: 'JSONStorage' object has no attribute '_handle'
```