### PR TITLE
Update database.py

### DIFF
--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -5,7 +5,7 @@ import pytest
 
 from tinydb import TinyDB, where
 from tinydb.storages import MemoryStorage
-
+from tinydb.middlewares import Middleware
 
 def test_purge(db):
     db.purge()
@@ -442,3 +442,13 @@ def test_purge_table():
 
     db.purge_table('non-existent-table-name')
     assert set([TinyDB.DEFAULT_TABLE]) == db.tables()
+
+def test_empty_write(tmpdir):
+    path = str(tmpdir.join('db.json'))
+    
+    class ReadOnlyMiddleware(Middleware):
+        def write(self, data):
+            raise AssertionError('No write for unchanged db')
+    
+    TinyDB(path)
+    TinyDB(path, storage=ReadOnlyMiddleware())

--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -110,7 +110,7 @@ class TinyDB(object):
 
         self._table_cache[name] = table
 
-        if not table._read():
+        if table._read() is None:
             table._write({})
 
         return table

--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -110,9 +110,9 @@ class TinyDB(object):
         table = self.table_class(StorageProxy(self._storage, name), **options)
 
         self._table_cache[name] = table
-
-        if table._read() is None:
-            table._write({})
+        
+        # table._read will create an empty table in the storage, if necessary
+        table._read()
 
         return table
 

--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -30,6 +30,7 @@ class StorageProxy(object):
         try:
             raw_data = (self._storage.read() or {})[self._table_name]
         except KeyError:
+            self.write({})
             return {}
 
         data = {}


### PR DESCRIPTION
Don't write db if _default is an empty Table.

If there are no documents in the _default table, TinyDB will write (and thus, re-serialize) the entire database.
This is because bool({}) == False, although the table does exist.

I have a JSON file under version control, which doesn't use the default table. Recently, I noticed that the file changes although I didn't change any document within the database. 
Apparently, TinyDB.__init__ reads the default table, which is empty in my case. An empty document evaluates to False in a boolean context, and TinyDB will write a new, empty table, effectively re-serializing the database on read.