### PR TITLE
add create_dirs kwarg to JSONStorage

### DIFF
--- a/tests/test_storages.py
+++ b/tests/test_storages.py
@@ -1,4 +1,6 @@
+import os
 import random
+import tempfile
 
 import pytest
 
@@ -69,6 +71,29 @@ def test_json_readwrite(tmpdir):
 
     db.remove(where('name') == 'A short one')
     assert get('A short one') is None
+
+
+def test_create_dirs():
+    temp_dir = tempfile.gettempdir()
+    db_dir = ''
+    db_file = ''
+
+    while True:
+        dname = os.path.join(temp_dir, str(random.getrandbits(20)))
+        if not os.path.exists(dname):
+            db_dir = dname
+            db_file = os.path.join(db_dir, 'db.json')
+            break
+
+    db_conn = JSONStorage(db_file, create_dirs=True)
+    db_conn.close()
+
+    db_exists = os.path.exists(db_file)
+
+    os.remove(db_file)
+    os.rmdir(db_dir)
+
+    assert db_exists
 
 
 def test_json_invalid_directory():

--- a/tinydb/storages.py
+++ b/tinydb/storages.py
@@ -15,7 +15,11 @@ except ImportError:
     import json
 
 
-def touch(fname, times=None):
+def touch(fname, times=None, create_dirs=False):
+    if create_dirs:
+        base_dir = os.path.dirname(fname)
+        if not os.path.exists(base_dir):
+            os.makedirs(base_dir)
     with open(fname, 'a'):
         os.utime(fname, times)
 
@@ -70,7 +74,7 @@ class JSONStorage(Storage):
     Store the data in a JSON file.
     """
 
-    def __init__(self, path, **kwargs):
+    def __init__(self, path, create_dirs=False, **kwargs):
         """
         Create a new instance.
 
@@ -81,7 +85,7 @@ class JSONStorage(Storage):
         """
 
         super(JSONStorage, self).__init__()
-        touch(path)  # Create file if not exists
+        touch(path, create_dirs=create_dirs)  # Create file if not exists
         self.kwargs = kwargs
         self._handle = open(path, 'r+')
 


### PR DESCRIPTION
Setting create_dirs=True in `__init__` will create the necessary parent directories to ensure db file will be created. This will further lessen what the user has to worry about.