### PR TITLE
added Python 3.6 to setup.py and passed all tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "pypy"
   - "pypy3.3-5.2-alpha1"
   - "nightly"
+  - "3.6"
   - "3.5"
   - "3.4"
   - "3.3"

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Operating System :: OS Independent"
     ],


### PR DESCRIPTION
added line ["Programming Language :: Python :: 3.6",] to classifiers in setup.py
ran setup.py install (on my machine with Python 3.6)
ran pytest, result: [85 passed, 2 skipped in 1.26 seconds] 2 skipped because they require Python 2