### PR TITLE
Fix unclosed files warnings on Python 3+

### DIFF
--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -79,11 +79,8 @@ def test_nested():
 def test_caching_json_write(tmpdir):
     path = str(tmpdir.join('test.db'))
 
-    db = TinyDB(path, storage=CachingMiddleware(JSONStorage))
-
-    db.insert({'key': 'value'})
-
-    db.close()
+    with TinyDB(path, storage=CachingMiddleware(JSONStorage)) as db:
+        db.insert({'key': 'value'})
 
     # Verify database filesize
     statinfo = os.stat(path)
@@ -95,5 +92,5 @@ def test_caching_json_write(tmpdir):
     del db
 
     # Repoen database
-    db = TinyDB(path, storage=CachingMiddleware(JSONStorage))
-    assert db.all() == [{'key': 'value'}]
+    with TinyDB(path, storage=CachingMiddleware(JSONStorage)) as db:
+        assert db.all() == [{'key': 'value'}]

--- a/tests/test_storages.py
+++ b/tests/test_storages.py
@@ -24,6 +24,7 @@ def test_json(tmpdir):
 
     # Verify contents
     assert element == storage.read()
+    storage.close()
 
 
 def test_json_kwargs(tmpdir):
@@ -44,6 +45,7 @@ def test_json_kwargs(tmpdir):
         }
     }
 }'''
+    db.close()
 
 
 def test_json_readwrite(tmpdir):
@@ -71,6 +73,8 @@ def test_json_readwrite(tmpdir):
 
     db.remove(where('name') == 'A short one')
     assert get('A short one') is None
+
+    db.close()
 
 
 def test_create_dirs():

--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -405,11 +405,13 @@ def test_insert_invalid_dict(tmpdir):
 def test_gc(tmpdir):
     # See https://github.com/msiemens/tinydb/issues/92
     path = str(tmpdir.join('db.json'))
-    table = TinyDB(path).table('foo')
+    db = TinyDB(path)
+    table = db.table('foo')
     table.insert({'something': 'else'})
     table.insert({'int': 13})
     assert len(table.search(where('int') == 13)) == 1
     assert table.all() == [{'something': 'else'}, {'int': 13}]
+    db.close()
 
 
 def test_non_default_table():
@@ -446,13 +448,13 @@ def test_purge_table():
 
 def test_empty_write(tmpdir):
     path = str(tmpdir.join('db.json'))
-    
+
     class ReadOnlyMiddleware(Middleware):
         def write(self, data):
             raise AssertionError('No write for unchanged db')
-    
-    TinyDB(path)
-    TinyDB(path, storage=ReadOnlyMiddleware())
+
+    TinyDB(path).close()
+    TinyDB(path, storage=ReadOnlyMiddleware()).close()
 
 
 def test_query_cache():


### PR DESCRIPTION
This PR ensure opened files are closed during tests (and so removes the raised warnings on Python 3+)