### PR TITLE
Remove absolute imports to support vendoring

### DIFF
--- a/tinydb/__init__.py
+++ b/tinydb/__init__.py
@@ -8,8 +8,8 @@ backend. It has support for handy querying and tables.
 
 Usage example:
 
->>> from . import TinyDB, where
->>> from .storages import MemoryStorage
+>>> from tinydb. import TinyDB, where
+>>> from tinydb.storages import MemoryStorage
 >>> db = TinyDB(storage=MemoryStorage)
 >>> db.insert({'data': 5})  # Insert into '_default' table
 >>> db.search(where('data') == 5)

--- a/tinydb/__init__.py
+++ b/tinydb/__init__.py
@@ -8,8 +8,8 @@ backend. It has support for handy querying and tables.
 
 Usage example:
 
->>> from tinydb import TinyDB, where
->>> from tinydb.storages import MemoryStorage
+>>> from . import TinyDB, where
+>>> from .storages import MemoryStorage
 >>> db = TinyDB(storage=MemoryStorage)
 >>> db.insert({'data': 5})  # Insert into '_default' table
 >>> db.search(where('data') == 5)
@@ -23,8 +23,8 @@ Usage example:
 5
 """
 
-from tinydb.queries import Query, where
-from tinydb.storages import Storage, JSONStorage
-from tinydb.database import TinyDB
+from .queries import Query, where
+from .storages import Storage, JSONStorage
+from .database import TinyDB
 
 __all__ = ('TinyDB', 'Storage', 'JSONStorage', 'Query', 'where')

--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -2,8 +2,8 @@
 Contains the :class:`database <tinydb.database.TinyDB>` and
 :class:`tables <tinydb.database.Table>` implementation.
 """
-from tinydb import JSONStorage
-from tinydb.utils import LRUCache, iteritems, itervalues
+from . import JSONStorage
+from .utils import LRUCache, iteritems, itervalues
 
 
 class Element(dict):

--- a/tinydb/middlewares.py
+++ b/tinydb/middlewares.py
@@ -2,7 +2,7 @@
 Contains the :class:`base class <tinydb.middlewares.Middleware>` for
 middlewares and implementations.
 """
-from tinydb import TinyDB
+from . import TinyDB
 
 
 class Middleware(object):

--- a/tinydb/queries.py
+++ b/tinydb/queries.py
@@ -19,7 +19,7 @@ False
 import re
 import sys
 
-from tinydb.utils import catch_warning, freeze
+from .utils import catch_warning, freeze
 
 __all__ = ('Query', 'where')
 

--- a/tinydb/storages.py
+++ b/tinydb/storages.py
@@ -6,7 +6,7 @@ implementations.
 from abc import ABCMeta, abstractmethod
 import os
 
-from tinydb.utils import with_metaclass
+from .utils import with_metaclass
 
 
 try:


### PR DESCRIPTION
Hi folks,

Thanks for this amazing project! I'm looking to bundle tinydb with another software library but couldn't due to the global references to `tinydb` in import statements.

This PR makes all imports relative, so that you can now do this.

```python
from my_library.vendor import tinydb
```

Let me know if there are any issues.