### PR TITLE
Enable TinyDB class for subclassing

### DIFF
--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -76,8 +76,8 @@ class TinyDB(object):
                         with ``args`` and ``kwargs``.
         """
 
-        storage = kwargs.pop('storage', TinyDB.DEFAULT_STORAGE)
-        table = kwargs.pop('default_table', TinyDB.DEFAULT_TABLE)
+        storage = kwargs.pop('storage', self.DEFAULT_STORAGE)
+        table = kwargs.pop('default_table', self.DEFAULT_TABLE)
 
         # Prepare the storage
         self._opened = False


### PR DESCRIPTION
I want to be able to do something like this:
```python
from tinydb import TinyDB
from tinydb.middlewares import CachingMiddleware
class YamlStorage(...):
    ...

class CachingYamlTDB(TinyDB):
    DEFAULT_STORAGE = CachingMiddleware(YamlStorage)
```
This PR enables TinyDB for such sublassing.