### PR TITLE
MessagePack support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,6 +163,13 @@ extensions: Contributions to TinyDB are welcome! Here's how to get started:
 Changelog
 *********
 
+**Unreleased** (2017-09-02)
+===========================
+
+- Added MessagePack support.
+- Added skipIf on tests that fails when using ujson.
+
+
 **v3.5.0** (2017-08-30)
 =======================
 

--- a/setup.py
+++ b/setup.py
@@ -48,4 +48,5 @@ setup(
     ],
 
     long_description=read('README.rst'),
+    install_requires=['msgpack-python']
 )

--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -1,11 +1,13 @@
 # coding=utf-8
 import sys
 
+import pip
 import pytest
 
 from tinydb import TinyDB, where
 from tinydb.storages import MemoryStorage
 from tinydb.middlewares import Middleware
+
 
 def test_purge(db):
     db.purge()
@@ -387,6 +389,8 @@ def test_insert_string(tmpdir):
         _db.insert({'int': 3})  # Does not fail
 
 
+@pytest.mark.skipif('ujson' in [pkg.key for pkg in pip.get_installed_distributions()],
+                    reason="set() is serializable in ujson")
 def test_insert_invalid_dict(tmpdir):
     path = str(tmpdir.join('db.json'))
 


### PR DESCRIPTION
Hi @msiemens,

So I was working with my [IPToCC](https://github.com/Code-ReaQtor/IPToCC) module and one of the issues I've encountered is that the database file is huge and I want to reduce it's size.

My solution was to use [MessagePack](http://msgpack.org/index.html). The current serializer/deserializer I used, [msgpack-python](https://github.com/msgpack/msgpack-python), is as fast as ujson but produces smaller file size (~50% smaller).

I've also added some fix to failing tests when using ujson as a parser.

Hope this will be merged to your `master` branch.

Cheers!