### PR TITLE
Docs: Use the term `documents` instead of `elements`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,7 +138,7 @@ Extensions
 | **Status:**      *stable*
 | **Description:** ``tinydb-smartcache`` provides a smart query cache for
                    TinyDB. It updates the query cache when
-                   inserting/removing/updating elements so the cache doesn't
+                   inserting/removing/updating documents so the cache doesn't
                    get invalidated. It's useful if you perform lots of queries
                    while the data changes only little.
 
@@ -199,7 +199,7 @@ v3.3.1 (2017-06-27)
 v3.3.0 (2017-06-05)
 ===================
 
-- Allow iterating over a database or table yielding all elements
+- Allow iterating over a database or table yielding all documents
   (see `pull request #139 <https://github.com/msiemens/tinydb/pull/139>`_).
 
 v3.2.3 (2017-04-22)
@@ -217,7 +217,7 @@ v3.2.2 (2017-01-16)
 v3.2.1 (2016-06-29)
 ===================
 
-- Fix a bug with queries on elements that have a ``path`` key
+- Fix a bug with queries on documents that have a ``path`` key
   (see `pull request #107 <https://github.com/msiemens/tinydb/pull/107>`_).
 - Don't write to the database file needlessly when opening the database
   (see `pull request #104 <https://github.com/msiemens/tinydb/pull/104>`_).
@@ -243,7 +243,7 @@ v3.1.3 (2016-02-14)
 v3.1.2 (2016-01-30)
 ===================
 
-- Fix a bug when using unhashable elements (lists, dicts) with
+- Fix a bug when using unhashable documents (lists, dicts) with
   ``Query.any`` or ``Query.all`` queries
   (see `a forum post by karibul <https://forum.m-siemens.de/d/4-error-with-any-and-all-queries>`_).
 
@@ -258,9 +258,9 @@ v3.1.1 (2016-01-23)
 v3.1.0 (2015-12-31)
 ===================
 
-- ``db.update(...)`` and ``db.remove(...)`` now return affected element IDs
+- ``db.update(...)`` and ``db.remove(...)`` now return affected document IDs
   (see `issue #83 <https://github.com/msiemens/tinydb/issues/83>`_).
-- Inserting an invalid element (i.e. not a ``dict``) now raises an error
+- Inserting an invalid document (i.e. not a ``dict``) now raises an error
   instead of corrupting the database (see
   `issue #74 <https://github.com/msiemens/tinydb/issues/74>`_).
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,7 +24,7 @@ API Documentation
     :exclude-members: __dict__, __weakref__
     :member-order: bysource
 
-    .. py:attribute:: eid
+    .. py:attribute:: doc_id
 
         The document's id
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,7 +26,7 @@ API Documentation
 
     .. py:attribute:: eid
 
-        The element's id
+        The document's id
 
 ``tinydb.queries``
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,7 +43,7 @@ v3.3.1 (2017-06-27)
 v3.3.0 (2017-06-05)
 ^^^^^^^^^^^^^^^^^^^
 
-- Allow iterating over a database or table yielding all elements
+- Allow iterating over a database or table yielding all documents
   (see `pull request #139 <https://github.com/msiemens/tinydb/pull/139>`_).
 
 v3.2.3 (2017-04-22)
@@ -61,7 +61,7 @@ v3.2.2 (2017-01-16)
 v3.2.1 (2016-06-29)
 ^^^^^^^^^^^^^^^^^^^
 
-- Fix a bug with queries on elements that have a ``path`` key
+- Fix a bug with queries on documents that have a ``path`` key
   (see `pull request #107 <https://github.com/msiemens/tinydb/pull/107>`_).
 - Don't write to the database file needlessly when opening the database
   (see `pull request #104 <https://github.com/msiemens/tinydb/pull/104>`_).
@@ -81,14 +81,14 @@ v3.2.0 (2016-04-25)
 v3.1.3 (2016-02-14)
 ^^^^^^^^^^^^^^^^^^^
 
-- Fix a bug when using unhashable elements (lists, dicts) with
+- Fix a bug when using unhashable documents (lists, dicts) with
   ``Query.any`` or ``Query.all`` queries
   (see `a forum post by karibul <https://forum.m-siemens.de/d/4-error-with-any-and-all-queries>`_).
 
 v3.1.2 (2016-01-30)
 ^^^^^^^^^^^^^^^^^^^
 
-- Fix a bug when using unhashable elements (lists, dicts) with
+- Fix a bug when using unhashable documents (lists, dicts) with
   ``Query.any`` or ``Query.all`` queries
   (see `a forum post by karibul <https://forum.m-siemens.de/d/4-error-with-any-and-all-queries>`_).
 
@@ -103,9 +103,9 @@ v3.1.1 (2016-01-23)
 v3.1.0 (2015-12-31)
 ^^^^^^^^^^^^^^^^^^^
 
-- ``db.update(...)`` and ``db.remove(...)`` now return affected element IDs
+- ``db.update(...)`` and ``db.remove(...)`` now return affected document IDs
   (see `issue #83 <https://github.com/msiemens/tinydb/issues/83>`_).
-- Inserting an invalid element (i.e. not a ``dict``) now raises an error
+- Inserting an invalid document (i.e. not a ``dict``) now raises an error
   instead of corrupting the database (see
   `issue #74 <https://github.com/msiemens/tinydb/issues/74>`_).
 
@@ -222,7 +222,7 @@ v2.0.0 (2014-09-05)
   (see `issue #18 <https://github.com/msiemens/tinydb/issues/18>`_).  Consider
   :ref:`tinyrecord` instead.
 
-- Better support for working with :ref:`Element IDs <element_ids>`.
+- Better support for working with :ref:`Document IDs <document_ids>`.
 - Added support for `nested comparisons <http://tinydb.readthedocs.io/en/v2.0.0/usage.html#nested-queries>`_.
 - Added ``all`` and ``any`` `comparisons on lists <http://tinydb.readthedocs.io/en/v2.0.0/usage.html#nested-queries>`_.
 - Added optional :<http://tinydb.readthedocs.io/en/v2.0.0/usage.html#smart-query-cache>`_.

--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -114,11 +114,11 @@ Now let's implement that:
             for table_name in data:
                 table = data[table_name]
 
-                for element_id in table:
-                    item = table[element_id]
+                for doc_id in table:
+                    item = table[doc_id]
 
                     if item == {}:
-                        del table[element_id]
+                        del table[doc_id]
 
             return data
 
@@ -126,11 +126,11 @@ Now let's implement that:
             for table_name in data:
                 table = data[table_name]
 
-                for element_id in table:
-                    item = table[element_id]
+                for doc_id in table:
+                    item = table[doc_id]
 
                     if item == {}:
-                        del table[element_id]
+                        del table[doc_id]
 
             self.storage.write(data)
 

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -47,6 +47,6 @@ Here are some extensions that might be useful to you:
 | **Status:**      *stable*
 | **Description:** ``tinydb-smartcache`` provides a smart query cache for
                    TinyDB. It updates the query cache when
-                   inserting/removing/updating elements so the cache doesn't
+                   inserting/removing/updating documents so the cache doesn't
                    get invalidated. It's useful if you perform lots of queries
                    while the data changes only little.

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -31,23 +31,23 @@ What about inserting some data? TinyDB expects the data to be Python ``dict``\s:
 >>> db.insert({'type': 'apple', 'count': 7})
 >>> db.insert({'type': 'peach', 'count': 3})
 
-.. note:: The ``insert`` method returns the inserted element's ID. Read more
-          about it here: :ref:`element_ids`.
+.. note:: The ``insert`` method returns the inserted document's ID. Read more
+          about it here: :ref:`document_ids`.
 
 
-Now you can get all elements stored in the database by running:
+Now you can get all documents stored in the database by running:
 
 >>> db.all()
 [{'count': 7, 'type': 'apple'}, {'count': 3, 'type': 'peach'}]
 
-You can also iter over stored elements:
+You can also iter over stored documents:
 
 >>> for item in db:
 >>>     print(item)
 {'count': 7, 'type': 'apple'}
 {'count': 3, 'type': 'peach'}
 
-Of course you'll also want to search for specific elements. Let's try:
+Of course you'll also want to search for specific documents. Let's try:
 
 >>> Fruit = Query()
 >>> db.search(Fruit.type == 'peach')
@@ -63,7 +63,7 @@ Next we'll update the ``count`` field of the apples:
 [{'count': 10, 'type': 'apple'}, {'count': 3, 'type': 'peach'}]
 
 
-In the same manner you can also remove elements:
+In the same manner you can also remove documents:
 
 >>> db.remove(Fruit.count < 5)
 >>> db.all()
@@ -84,31 +84,31 @@ Before we dive deeper, let's recapitulate the basics:
 +-------------------------------+---------------------------------------------------------------+
 | **Inserting**                                                                                 |
 +-------------------------------+---------------------------------------------------------------+
-| ``db.insert(...)``            | Insert an element                                             |
+| ``db.insert(...)``            | Insert an document                                            |
 +-------------------------------+---------------------------------------------------------------+
 | **Getting data**                                                                              |
 +-------------------------------+---------------------------------------------------------------+
-| ``db.all()``                  | Get all elements                                              |
+| ``db.all()``                  | Get all documents                                             |
 +-------------------------------+---------------------------------------------------------------+
-| ``iter(db)``                  | Iter over all elements                                        |
+| ``iter(db)``                  | Iter over all documents                                       |
 +-------------------------------+---------------------------------------------------------------+
-| ``db.search(query)``          | Get a list of elements matching the query                     |
+| ``db.search(query)``          | Get a list of documents matching the query                    |
 +-------------------------------+---------------------------------------------------------------+
 | **Updating**                                                                                  |
 +-------------------------------+---------------------------------------------------------------+
-| ``db.update(fields, query)``  | Update all elements matching the query to contain ``fields``  |
+| ``db.update(fields, query)``  | Update all documents matching the query to contain ``fields`` |
 +-------------------------------+---------------------------------------------------------------+
 | **Removing**                                                                                  |
 +-------------------------------+---------------------------------------------------------------+
-| ``db.remove(query)``          | Remove all elements matching the query                        |
+| ``db.remove(query)``          | Remove all documents matching the query                       |
 +-------------------------------+---------------------------------------------------------------+
-| ``db.purge()``                | Purge all elements                                            |
+| ``db.purge()``                | Purge all documents                                           |
 +-------------------------------+---------------------------------------------------------------+
 | **Querying**                                                                                  |
 +-------------------------------+---------------------------------------------------------------+
 | ``Query()``                   | Create a new query object                                     |
 +-------------------------------+---------------------------------------------------------------+
-| ``Query().field == 2``        | Match any element that has a key ``field`` with value         |
+| ``Query().field == 2``        | Match any document that has a key ``field`` with value        |
 |                               | ``== 2`` (also possible: ``!=`` ``>`` ``>=`` ``<`` ``<=``)    |
 +-------------------------------+---------------------------------------------------------------+
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -138,8 +138,8 @@ Now let's search this table using nested ``any``/``all`` queries:
 [{'name': 'user', 'permissions': [{'type': 'read'}]}]
 
 
-As you can see, ``any`` tests if there is *at least one* element matching
-the query while ``all`` ensures *all* elements match the query.
+As you can see, ``any`` tests if there is *at least one* document matching
+the query while ``all`` ensures *all* documents match the query.
 
 Query modifiers
 ...............
@@ -166,39 +166,39 @@ Recap
 
 Let's review the query operations we've learned:
 
-+-------------------------------------+-----------------------------------------------------------+
-| **Queries**                                                                                     |
-+-------------------------------------+-----------------------------------------------------------+
-| ``Query().field.exists()``          | Match any element where a field called ``field`` exists   |
-+-------------------------------------+-----------------------------------------------------------+
-| ``Query().field.matches(regex)``    | Match any element with the whole field matching the       |
-|                                     | regular expression                                        |
-+-------------------------------------+-----------------------------------------------------------+
-| ``Query().field.search(regex)``     | Match any element with a substring of the field matching  |
-|                                     | the regular expression                                    |
-+-------------------------------------+-----------------------------------------------------------+
-| ``Query().field.test(func, *args)`` | Matches any element for which the function returns        |
-|                                     | ``True``                                                  |
-+-------------------------------------+-----------------------------------------------------------+
-| ``Query().field.all(query | list)`` | If given a query, matches all elements where all elements |
-|                                     | in the list ``field`` match the query.                    |
-|                                     | If given a list, matches all elements where all elements  |
-|                                     | in the list ``field`` are a member of the given list      |
-+-------------------------------------+-----------------------------------------------------------+
-| ``Query().field.any(query | list)`` | If given a query, matches all elements where at least one |
-|                                     | element in the list ``field`` match the query.            |
-|                                     | If given a list, matches all elements where at least one  |
-|                                     | elements in the list ``field`` are a member of the given  |
-|                                     | list                                                      |
-+-------------------------------------+-----------------------------------------------------------+
-| **Logical operations on queries**                                                               |
-+-------------------------------------+-----------------------------------------------------------+
-| ``~ query``                         | Match elements that don't match the query                 |
-+-------------------------------------+-----------------------------------------------------------+
-| ``(query1) & (query2)``             | Match elements that match both queries                    |
-+-------------------------------------+-----------------------------------------------------------+
-| ``(query1) | (query2)``             | Match elements that match at least one of the queries     |
-+-------------------------------------+-----------------------------------------------------------+
++-------------------------------------+-------------------------------------------------------------+
+| **Queries**                                                                                       |
++-------------------------------------+-------------------------------------------------------------+
+| ``Query().field.exists()``          | Match any document where a field called ``field`` exists    |
++-------------------------------------+-------------------------------------------------------------+
+| ``Query().field.matches(regex)``    | Match any document with the whole field matching the        |
+|                                     | regular expression                                          |
++-------------------------------------+-------------------------------------------------------------+
+| ``Query().field.search(regex)``     | Match any document with a substring of the field matching   |
+|                                     | the regular expression                                      |
++-------------------------------------+-------------------------------------------------------------+
+| ``Query().field.test(func, *args)`` | Matches any document for which the function returns         |
+|                                     | ``True``                                                    |
++-------------------------------------+-------------------------------------------------------------+
+| ``Query().field.all(query | list)`` | If given a query, matches all documents where all documents |
+|                                     | in the list ``field`` match the query.                      |
+|                                     | If given a list, matches all documents where all documents  |
+|                                     | in the list ``field`` are a member of the given list        |
++-------------------------------------+-------------------------------------------------------------+
+| ``Query().field.any(query | list)`` | If given a query, matches all documents where at least one  |
+|                                     | document in the list ``field`` match the query.             |
+|                                     | If given a list, matches all documents where at least one   |
+|                                     | documents in the list ``field`` are a member of the given   |
+|                                     | list                                                        |
++-------------------------------------+-------------------------------------------------------------+
+| **Logical operations on queries**                                                                 |
++-------------------------------------+-------------------------------------------------------------+
+| ``~ query``                         | Match documents that don't match the query                  |
++-------------------------------------+-------------------------------------------------------------+
+| ``(query1) & (query2)``             | Match documents that match both queries                     |
++-------------------------------------+-------------------------------------------------------------+
+| ``(query1) | (query2)``             | Match documents that match at least one of the queries      |
++-------------------------------------+-------------------------------------------------------------+
 
 Handling Data
 -------------
@@ -209,8 +209,8 @@ your database.
 Inserting data
 ..............
 
-As already described you can insert an element using ``db.insert(...)``.
-In case you want to insert multiple elements, you can use ``db.insert_multiple(...)``:
+As already described you can insert an document using ``db.insert(...)``.
+In case you want to insert multiple documents, you can use ``db.insert_multiple(...)``:
 
 >>> db.insert_multiple([{'name': 'John', 'age': 22}, {'name': 'John', 'age': 37}])
 >>> db.insert_multiple({'int': 1, 'value': i} for i in range(2))
@@ -218,23 +218,23 @@ In case you want to insert multiple elements, you can use ``db.insert_multiple(.
 Updating data
 .............
 
-Sometimes you want to update all elements in your database. In this case, you
+Sometimes you want to update all documents in your database. In this case, you
 can leave out the ``query`` argument:
 
 >>> db.update({'foo': 'bar'})
 
 When passing a dict to ``db.update(fields, query)``, it only allows you to
-update an element by adding or overwriting its values. But sometimes you may
+update an document by adding or overwriting its values. But sometimes you may
 need to e.g. remove one field or increment its value. In that case you can
 pass a function instead of ``fields``:
 
 >>> from tinydb.operations import delete
 >>> db.update(delete('key1'), User.name == 'John')
 
-This will remove the key ``key1`` from all matching elements. TinyDB comes
+This will remove the key ``key1`` from all matching documents. TinyDB comes
 with these operations:
 
-- ``delete(key)``: delete a key from the element
+- ``delete(key)``: delete a key from the document
 - ``increment(key)``: increment the value of a key
 - ``decrement(key)``: decrement the value of a key
 - ``add(key, value)``: add ``value`` to the value of a key (also works for strings)
@@ -243,9 +243,9 @@ with these operations:
 
 Of course you also can write your own operations:
 
->>> def your_operation(your_arguments):
-...     def transform(element):
-...         # do something with the element
+>>> def your_operation(yodocumentur_arguments):
+...     def transform(doc):
+...         # do something with the document
 ...         # ...
 ...     return transform
 ...
@@ -255,13 +255,13 @@ Retrieving data
 ...............
 
 There are several ways to retrieve data from your database. For instance you
-can get the number of stored elements:
+can get the number of stored documents:
 
 >>> len(db)
 3
 
 Then of course you can use ``db.search(...)`` as described in the :doc:`getting-started`
-section. But sometimes you want to get only one matching element. Instead of using
+section. But sometimes you want to get only one matching document. Instead of using
 
 >>> try:
 ...     result = db.search(User.name == 'John')[0]
@@ -278,15 +278,15 @@ None
 
 .. caution::
 
-    If multiple elements match the query, probably a random one of them will
+    If multiple documents match the query, probably a random one of them will
     be returned!
 
-Often you don't want to search for elements but only know whether they are
+Often you don't want to search for documents but only know whether they are
 stored in the database. In this case ``db.contains(...)`` is your friend:
 
 >>> db.contains(User.name == 'John')
 
-In a similar manner you can look up the number of elements matching a query:
+In a similar manner you can look up the number of documents matching a query:
 
 >>> db.count(User.name == 'John')
 2
@@ -299,39 +299,39 @@ Let's summarize the ways to handle data:
 +-------------------------------+---------------------------------------------------------------+
 | **Inserting data**                                                                            |
 +-------------------------------+---------------------------------------------------------------+
-| ``db.insert_multiple(...)``   | Insert multiple elements                                      |
+| ``db.insert_multiple(...)``   | Insert multiple documents                                     |
 +-------------------------------+---------------------------------------------------------------+
 | **Updating data**                                                                             |
 +-------------------------------+---------------------------------------------------------------+
-| ``db.update(operation, ...)`` | Update all matching elements with a special operation         |
+| ``db.update(operation, ...)`` | Update all matching documents with a special operation        |
 +-------------------------------+---------------------------------------------------------------+
 | **Retrieving data**                                                                           |
 +-------------------------------+---------------------------------------------------------------+
-| ``len(db)``                   | Get the number of elements in the database                    |
+| ``len(db)``                   | Get the number of documents in the database                   |
 +-------------------------------+---------------------------------------------------------------+
-| ``db.get(query)``             | Get one element matching the query                            |
+| ``db.get(query)``             | Get one document matching the query                           |
 +-------------------------------+---------------------------------------------------------------+
-| ``db.contains(query)``        | Check if the database contains a matching element             |
+| ``db.contains(query)``        | Check if the database contains a matching document            |
 +-------------------------------+---------------------------------------------------------------+
-| ``db.count(query)``           | Get the number of matching elements                           |
+| ``db.count(query)``           | Get the number of matching documents                          |
 +-------------------------------+---------------------------------------------------------------+
 
 
-.. _element_ids:
+.. _document_ids:
 
-Using Element IDs
------------------
+Using Document IDs
+------------------
 
-Internally TinyDB associates an ID with every element you insert. It's returned
-after inserting an element:
+Internally TinyDB associates an ID with every document you insert. It's returned
+after inserting an document:
 
 >>> db.insert({'name': 'John', 'age': 22})
 3
 >>> db.insert_multiple([{...}, {...}, {...}])
 [4, 5, 6]
 
-In addition you can get the ID of already inserted elements using
-``element.eid``. This works both with ``get`` and ``all``:
+In addition you can get the ID of already inserted documents using
+``document.eid``. This works both with ``get`` and ``all``:
 
 >>> el = db.get(User.name == 'John')
 >>> el.eid
@@ -356,23 +356,23 @@ Recap
 Let's sum up the way TinyDB supports working with IDs:
 
 +----------------------------------+---------------------------------------------------------------+
-| **Getting an element's ID**                                                                      |
+| **Getting an document's ID**                                                                     |
 +----------------------------------+---------------------------------------------------------------+
-| ``db.insert(...)``               | Returns the inserted element's ID                             |
+| ``db.insert(...)``               | Returns the inserted document's ID                            |
 +----------------------------------+---------------------------------------------------------------+
-| ``db.insert_multiple(...)``      | Returns the inserted elements' ID                             |
+| ``db.insert_multiple(...)``      | Returns the inserted documents' ID                            |
 +----------------------------------+---------------------------------------------------------------+
-| ``element.eid``                  | Get the ID of an element fetched from the db                  |
+| ``document.eid``                  | Get the ID of an document fetched from the db                |
 +----------------------------------+---------------------------------------------------------------+
 | **Working with IDs**                                                                             |
 +----------------------------------+---------------------------------------------------------------+
-| ``db.get(eid=...)``              | Get the element with the given ID                             |
+| ``db.get(eid=...)``              | Get the document with the given ID                            |
 +----------------------------------+---------------------------------------------------------------+
-| ``db.contains(eids=[...])``      | Check if the db contains elements with one of the given IDs   |
+| ``db.contains(eids=[...])``      | Check if the db contains documents with one of the given IDs  |
 +----------------------------------+---------------------------------------------------------------+
-| ``db.update({...}, eids=[...])`` | Update all elements with the given IDs                        |
+| ``db.update({...}, eids=[...])`` | Update all documents with the given IDs                       |
 +----------------------------------+---------------------------------------------------------------+
-| ``db.remove(eids=[...])``        | Remove all elements with the given IDs                        |
+| ``db.remove(eids=[...])``        | Remove all documents with the given IDs                       |
 +----------------------------------+---------------------------------------------------------------+
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -331,23 +331,23 @@ after inserting an document:
 [4, 5, 6]
 
 In addition you can get the ID of already inserted documents using
-``document.eid``. This works both with ``get`` and ``all``:
+``document.doc_id``. This works both with ``get`` and ``all``:
 
 >>> el = db.get(User.name == 'John')
->>> el.eid
+>>> el.doc_id
 3
 >>> el = db.all()[0]
->>> el.eid
+>>> el.doc_id
 12
 
 Different TinyDB methods also work with IDs, namely: ``update``, ``remove``,
 ``contains`` and ``get``. The first two also return a list of affected IDs.
 
->>> db.update({'value': 2}, eids=[1, 2])
->>> db.contains(eids=[1])
+>>> db.update({'value': 2}, doc_ids=[1, 2])
+>>> db.contains(doc_ids=[1])
 True
->>> db.remove(eids=[1, 2])
->>> db.get(eid=3)
+>>> db.remove(doc_ids=[1, 2])
+>>> db.get(doc_id=3)
 {...}
 
 Recap
@@ -355,25 +355,26 @@ Recap
 
 Let's sum up the way TinyDB supports working with IDs:
 
-+----------------------------------+---------------------------------------------------------------+
++-------------------------------------+------------------------------------------------------------+
 | **Getting an document's ID**                                                                     |
-+----------------------------------+---------------------------------------------------------------+
-| ``db.insert(...)``               | Returns the inserted document's ID                            |
-+----------------------------------+---------------------------------------------------------------+
-| ``db.insert_multiple(...)``      | Returns the inserted documents' ID                            |
-+----------------------------------+---------------------------------------------------------------+
-| ``document.eid``                  | Get the ID of an document fetched from the db                |
-+----------------------------------+---------------------------------------------------------------+
++-------------------------------------+------------------------------------------------------------+
+| ``db.insert(...)``                  | Returns the inserted document's ID                         |
++-------------------------------------+------------------------------------------------------------+
+| ``db.insert_multiple(...)``         | Returns the inserted documents' ID                         |
++-------------------------------------+------------------------------------------------------------+
+| ``document.doc_id``                 | Get the ID of an document fetched from the db              |
++-------------------------------------+------------------------------------------------------------+
 | **Working with IDs**                                                                             |
-+----------------------------------+---------------------------------------------------------------+
-| ``db.get(eid=...)``              | Get the document with the given ID                            |
-+----------------------------------+---------------------------------------------------------------+
-| ``db.contains(eids=[...])``      | Check if the db contains documents with one of the given IDs  |
-+----------------------------------+---------------------------------------------------------------+
-| ``db.update({...}, eids=[...])`` | Update all documents with the given IDs                       |
-+----------------------------------+---------------------------------------------------------------+
-| ``db.remove(eids=[...])``        | Remove all documents with the given IDs                       |
-+----------------------------------+---------------------------------------------------------------+
++-------------------------------------+------------------------------------------------------------+
+| ``db.get(doc_id=...)``              | Get the document with the given ID                         |
++-------------------------------------+------------------------------------------------------------+
+| ``db.contains(doc_ids=[...])``      | Check if the db contains documents with one of the given   |
+|                                     | IDs                                                        |
++-------------------------------------+------------------------------------------------------------+
+| ``db.update({...}, doc_ids=[...])`` | Update all documents with the given IDs                    |
++-------------------------------------+------------------------------------------------------------+
+| ``db.remove(doc_ids=[...])``        | Remove all documents with the given IDs                    |
++-------------------------------------+------------------------------------------------------------+
 
 
 Tables

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -8,19 +8,18 @@ if 'xrange' not in dir(__builtins__):
     # noinspection PyShadowingBuiltins
     xrange = range  # Python 3 support
 
-
-element = {'none': [None, None], 'int': 42, 'float': 3.1415899999999999,
-           'list': ['LITE', 'RES_ACID', 'SUS_DEXT'],
-           'dict': {'hp': 13, 'sp': 5},
-           'bool': [True, False, True, False]}
+doc = {'none': [None, None], 'int': 42, 'float': 3.1415899999999999,
+       'list': ['LITE', 'RES_ACID', 'SUS_DEXT'],
+       'dict': {'hp': 13, 'sp': 5},
+       'bool': [True, False, True, False]}
 
 
 def test_caching(storage):
     # Write contents
-    storage.write(element)
+    storage.write(doc)
 
     # Verify contents
-    assert element == storage.read()
+    assert doc == storage.read()
 
 
 def test_caching_read():
@@ -36,10 +35,10 @@ def test_caching_write_many(storage):
 
     # Write contents
     for x in xrange(2):
-        storage.write(element)
+        storage.write(doc)
         assert storage.memory is None  # Still cached
 
-    storage.write(element)
+    storage.write(doc)
 
     # Verify contents: Cache should be emptied and written to storage
     assert storage.memory
@@ -48,12 +47,12 @@ def test_caching_write_many(storage):
 def test_caching_flush(storage):
     # Write contents
     for _ in range(CachingMiddleware.WRITE_CACHE_SIZE - 1):
-        storage.write(element)
+        storage.write(doc)
 
     # Not yet flushed...
     assert storage.memory is None
 
-    storage.write(element)
+    storage.write(doc)
 
     # Verify contents: Cache should be emptied and written to storage
     assert storage.memory
@@ -61,7 +60,7 @@ def test_caching_flush(storage):
 
 def test_caching_flush_manually(storage):
     # Write contents
-    storage.write(element)
+    storage.write(doc)
 
     storage.flush()
 
@@ -71,7 +70,7 @@ def test_caching_flush_manually(storage):
 
 def test_caching_write(storage):
     # Write contents
-    storage.write(element)
+    storage.write(doc)
 
     storage.close()
 
@@ -84,10 +83,10 @@ def test_nested():
     storage()  # Initialization
 
     # Write contents
-    storage.write(element)
+    storage.write(doc)
 
     # Verify contents
-    assert element == storage.read()
+    assert doc == storage.read()
 
 
 def test_caching_json_write(tmpdir):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -210,9 +210,12 @@ def test_all():
     assert not query({})
     assert hash(query)
 
-    query = Query().followers.all([{'name': 'john'}, {'age': 17}])
-    assert query({'followers': [{'name': 'john'}, {'age': 17}]})
-    assert not query({'followers': [{'name': 'john'}, {'age': 18}]})
+    query = Query().followers.all([{'name': 'jane'}, {'name': 'john'}])
+    assert query({'followers': [{'name': 'john'}, {'name': 'jane'}]})
+    assert query({'followers': [{'name': 'john'},
+                                {'name': 'jane'},
+                                {'name': 'bob'}]})
+    assert not query({'followers': [{'name': 'john'}, {'name': 'bob'}]})
     assert hash(query)
 
 

--- a/tests/test_storages.py
+++ b/tests/test_storages.py
@@ -4,16 +4,15 @@ import tempfile
 
 import pytest
 
-
-random.seed()
-
 from tinydb import TinyDB, where
 from tinydb.storages import JSONStorage, MemoryStorage, Storage
 
+random.seed()
+
 doc = {'none': [None, None], 'int': 42, 'float': 3.1415899999999999,
-           'list': ['LITE', 'RES_ACID', 'SUS_DEXT'],
-           'dict': {'hp': 13, 'sp': 5},
-           'bool': [True, False, True, False]}
+       'list': ['LITE', 'RES_ACID', 'SUS_DEXT'],
+       'dict': {'hp': 13, 'sp': 5},
+       'bool': [True, False, True, False]}
 
 
 def test_json(tmpdir):

--- a/tests/test_storages.py
+++ b/tests/test_storages.py
@@ -10,7 +10,7 @@ random.seed()
 from tinydb import TinyDB, where
 from tinydb.storages import JSONStorage, MemoryStorage, Storage
 
-element = {'none': [None, None], 'int': 42, 'float': 3.1415899999999999,
+doc = {'none': [None, None], 'int': 42, 'float': 3.1415899999999999,
            'list': ['LITE', 'RES_ACID', 'SUS_DEXT'],
            'dict': {'hp': 13, 'sp': 5},
            'bool': [True, False, True, False]}
@@ -20,10 +20,10 @@ def test_json(tmpdir):
     # Write contents
     path = str(tmpdir.join('test.db'))
     storage = JSONStorage(path)
-    storage.write(element)
+    storage.write(doc)
 
     # Verify contents
-    assert element == storage.read()
+    assert doc == storage.read()
     storage.close()
 
 
@@ -110,10 +110,10 @@ def test_json_invalid_directory():
 def test_in_memory():
     # Write contents
     storage = MemoryStorage()
-    storage.write(element)
+    storage.write(doc)
 
     # Verify contents
-    assert element == storage.read()
+    assert doc == storage.read()
 
     # Test case for #21
     other = MemoryStorage()

--- a/tests/test_storages.py
+++ b/tests/test_storages.py
@@ -86,7 +86,7 @@ def test_create_dirs():
             db_file = os.path.join(db_dir, 'db.json')
             break
 
-    with pytest.raises(OSError):
+    with pytest.raises(IOError):
         JSONStorage(db_file)
 
     JSONStorage(db_file, create_dirs=True).close()

--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -518,3 +518,9 @@ def test_eids(db):
     with pytest.warns(DeprecationWarning):
         db.remove(eids=[1])
         assert not db.contains(where('field') == 'value')
+
+    with pytest.raises(TypeError):
+        db.remove(eids=[1], doc_ids=[1])
+
+    with pytest.raises(TypeError):
+        db.get(eid=[1], doc_id=[1])

--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -7,6 +7,7 @@ from tinydb import TinyDB, where
 from tinydb.storages import MemoryStorage
 from tinydb.middlewares import Middleware
 
+
 def test_purge(db):
     db.purge()
 

--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -109,7 +109,7 @@ def test_remove_multiple(db):
 
 
 def test_remove_ids(db):
-    db.remove(eids=[1, 2])
+    db.remove(doc_ids=[1, 2])
 
     assert len(db) == 1
 
@@ -167,7 +167,7 @@ def test_update_transform(db):
 
 
 def test_update_ids(db):
-    db.update({'int': 2}, eids=[1, 2])
+    db.update({'int': 2}, doc_ids=[1, 2])
 
     assert db.count(where('int') == 2) == 2
 
@@ -187,8 +187,8 @@ def test_get(db):
 
 def test_get_ids(db):
     el = db.all()[0]
-    assert db.get(eid=el.eid) == el
-    assert db.get(eid=float('NaN')) is None
+    assert db.get(doc_id=el.doc_id) == el
+    assert db.get(doc_id=float('NaN')) is None
 
 
 def test_count(db):
@@ -202,8 +202,8 @@ def test_contains(db):
 
 
 def test_contains_ids(db):
-    assert db.contains(eids=[1, 2])
-    assert not db.contains(eids=[88])
+    assert db.contains(doc_ids=[1, 2])
+    assert not db.contains(doc_ids=[88])
 
 
 def test_get_idempotent(db):
@@ -268,7 +268,7 @@ def test_unique_ids(tmpdir):
     with TinyDB(path) as _db:
         data = _db.all()
 
-        assert data[0].eid != data[1].eid
+        assert data[0].doc_id != data[1].doc_id
 
     # Verify ids stay unique when inserting/removing
     with TinyDB(path) as _db:
@@ -278,7 +278,7 @@ def test_unique_ids(tmpdir):
 
         assert len(_db) == 4
 
-        ids = [e.eid for e in _db.all()]
+        ids = [e.doc_id for e in _db.all()]
         assert len(ids) == len(set(ids))
 
 
@@ -351,7 +351,7 @@ def test_unicode_json(tmpdir):
         assert _db.contains(where('value') == unic_str2)
 
 
-def test_eids_json(tmpdir):
+def test_doc_ids_json(tmpdir):
     """
     Regression test for issue #45
     """
@@ -368,17 +368,17 @@ def test_eids_json(tmpdir):
                                     {'int': 1, 'char': 'b'},
                                     {'int': 1, 'char': 'c'}]) == [1, 2, 3]
 
-        assert _db.contains(eids=[1, 2])
-        assert not _db.contains(eids=[88])
+        assert _db.contains(doc_ids=[1, 2])
+        assert not _db.contains(doc_ids=[88])
 
-        _db.update({'int': 2}, eids=[1, 2])
+        _db.update({'int': 2}, doc_ids=[1, 2])
         assert _db.count(where('int') == 2) == 2
 
         el = _db.all()[0]
-        assert _db.get(eid=el.eid) == el
-        assert _db.get(eid=float('NaN')) is None
+        assert _db.get(doc_id=el.doc_id) == el
+        assert _db.get(doc_id=float('NaN')) is None
 
-        _db.remove(eids=[1, 2])
+        _db.remove(doc_ids=[1, 2])
         assert len(_db) == 1
 
 
@@ -498,3 +498,22 @@ def test_query_cache():
 
 def test_tinydb_is_iterable(db):
     assert [r for r in db] == db.all()
+
+
+def test_eids(db):
+    with pytest.warns(DeprecationWarning):
+        assert db.contains(eids=[1]) is True
+
+    with pytest.warns(DeprecationWarning):
+        db.update({'field': 'value'}, eids=[1])
+        assert db.contains(where('field') == 'value')
+
+    with pytest.warns(DeprecationWarning):
+        doc = db.get(eid=1)
+
+    with pytest.warns(DeprecationWarning):
+        assert doc.eid == 1
+
+    with pytest.warns(DeprecationWarning):
+        db.remove(eids=[1])
+        assert not db.contains(where('field') == 'value')

--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -136,7 +136,8 @@ class TinyDB(object):
         if name in self._table_cache:
             return self._table_cache[name]
 
-        table = self.table_class(StorageProxy(self._storage, name), name, **options)
+        table = self.table_class(StorageProxy(self._storage, name), name,
+                                 **options)
 
         self._table_cache[name] = table
 

--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -2,22 +2,54 @@
 Contains the :class:`database <tinydb.database.TinyDB>` and
 :class:`tables <tinydb.database.Table>` implementation.
 """
+import warnings
+
 from . import JSONStorage
 from .utils import LRUCache, iteritems, itervalues
 
 
-class Element(dict):
+class Document(dict):
     """
     Represents a document stored in the database.
 
     This is a transparent proxy for database records. It exists
-    to provide a way to access an record's id via ``el.eid``.
+    to provide a way to access an record's id via ``el.doc_id``.
     """
-    def __init__(self, value, eid, **kwargs):
-        super(Element, self).__init__(**kwargs)
+    def __init__(self, value, doc_id, **kwargs):
+        super(Document, self).__init__(**kwargs)
 
         self.update(value)
-        self.eid = eid
+        self.doc_id = doc_id
+
+    @property
+    def eid(self):
+        warnings.warn('eid has been renamed to doc_id', DeprecationWarning)
+        return self.doc_id
+
+
+Element = Document
+
+
+def _get_doc_id(doc_id, eid):
+    if eid is not None:
+        if doc_id is not None:
+            raise TypeError('cannot pass both eid and doc_id')
+
+        warnings.warn('eid has been renamed to doc_ids', DeprecationWarning)
+        return eid
+    else:
+        return doc_id
+
+
+def _get_doc_ids(doc_ids, eids):
+    if eids is not None:
+        if doc_ids is not None:
+            raise TypeError('cannot pass both eids and doc_ids')
+
+        warnings.warn('eids has been renamed to doc_ids', DeprecationWarning)
+        return eids
+    else:
+        return doc_ids
 
 
 class StorageProxy(object):
@@ -34,8 +66,8 @@ class StorageProxy(object):
 
         data = {}
         for key, val in iteritems(raw_data):
-            eid = int(key)
-            data[eid] = Element(val, eid)
+            doc_id = int(key)
+            data[doc_id] = Element(val, doc_id)
 
         return data
 
@@ -217,7 +249,7 @@ class Table(object):
         """
         return self._name
 
-    def process_elements(self, func, cond=None, eids=None):
+    def process_elements(self, func, cond=None, doc_ids=None, eids=None):
         """
         Helper function for processing all documents specified by condition
         or IDs.
@@ -235,36 +267,38 @@ class Table(object):
                      first argument: all data
                      second argument: the current eid
         :param cond: query that matches documents to use, or
-        :param eids: list of document IDs to use
+        :param doc_ids: list of document IDs to use
+        :param doc_ids: list of document IDs to use (deprecated)
         :returns: the document IDs that were affected during processed
         """
 
+        doc_ids = _get_doc_ids(doc_ids, eids)
         data = self._read()
 
-        if eids is not None:
+        if doc_ids is not None:
             # Processed document specified by id
-            for eid in eids:
-                func(data, eid)
+            for doc_id in doc_ids:
+                func(data, doc_id)
 
         elif cond is not None:
-            # Collect affected eids
-            eids = []
+            # Collect affected doc_ids
+            doc_ids = []
 
             # Processed documents specified by condition
-            for eid in list(data):
-                if cond(data[eid]):
-                    func(data, eid)
-                    eids.append(eid)
+            for doc_id in list(data):
+                if cond(data[doc_id]):
+                    func(data, doc_id)
+                    doc_ids.append(doc_id)
         else:
             # Processed documents
-            eids = list(data)
+            doc_ids = list(data)
 
-            for eid in eids:
-                func(data, eid)
+            for doc_id in doc_ids:
+                func(data, doc_id)
 
         self._write(data)
 
-        return eids
+        return doc_ids
 
     def clear_cache(self):
         """
@@ -340,16 +374,16 @@ class Table(object):
         :returns: the inserted document's ID
         """
 
-        eid = self._get_next_id()
+        doc_id = self._get_next_id()
 
         if not isinstance(document, dict):
             raise ValueError('Document is not a dictionary')
 
         data = self._read()
-        data[eid] = document
+        data[doc_id] = document
         self._write(data)
 
-        return eid
+        return doc_id
 
     def insert_multiple(self, documents):
         """
@@ -359,38 +393,40 @@ class Table(object):
         :returns: a list containing the inserted documents' IDs
         """
 
-        eids = []
+        doc_ids = []
         data = self._read()
 
         for doc in documents:
-            eid = self._get_next_id()
-            eids.append(eid)
+            doc_id = self._get_next_id()
+            doc_ids.append(doc_id)
 
-            data[eid] = doc
+            data[doc_id] = doc
 
         self._write(data)
 
-        return eids
+        return doc_ids
 
-    def remove(self, cond=None, eids=None):
+    def remove(self, cond=None, doc_ids=None, eids=None):
         """
         Remove all matching documents.
 
         :param cond: the condition to check against
         :type cond: query
-        :param eids: a list of document IDs
-        :type eids: list
+        :param doc_ids: a list of document IDs
+        :type doc_ids: list
         :returns: a list containing the removed document's ID
         """
-        if cond is None and eids is None:
+        doc_ids = _get_doc_ids(doc_ids, eids)
+
+        if cond is None and doc_ids is None:
             raise RuntimeError('Use purge() to remove all documents')
 
         return self.process_elements(
-            lambda data, eid: data.pop(eid),
-            cond, eids
+            lambda data, doc_id: data.pop(doc_id),
+            cond, doc_ids
         )
 
-    def update(self, fields, cond=None, eids=None):
+    def update(self, fields, cond=None, doc_ids=None, eids=None):
         """
         Update all matching documents to have a given set of fields.
 
@@ -399,20 +435,21 @@ class Table(object):
         :type fields: dict | dict -> None
         :param cond: which documents to update
         :type cond: query
-        :param eids: a list of document IDs
-        :type eids: list
+        :param doc_ids: a list of document IDs
+        :type doc_ids: list
         :returns: a list containing the updated document's ID
         """
+        doc_ids = _get_doc_ids(doc_ids, eids)
 
         if callable(fields):
             return self.process_elements(
-                lambda data, eid: fields(data[eid]),
-                cond, eids
+                lambda data, doc_id: fields(data[doc_id]),
+                cond, doc_ids
             )
         else:
             return self.process_elements(
-                lambda data, eid: data[eid].update(fields),
-                cond, eids
+                lambda data, doc_id: data[doc_id].update(fields),
+                cond, doc_ids
             )
 
     def purge(self):
@@ -442,7 +479,7 @@ class Table(object):
 
         return docs[:]
 
-    def get(self, cond=None, eid=None):
+    def get(self, cond=None, doc_id=None, eid=None):
         """
         Get exactly one document specified by a query or and ID.
 
@@ -451,18 +488,19 @@ class Table(object):
         :param cond: the condition to check against
         :type cond: Query
 
-        :param eid: the document's ID
+        :param doc_id: the document's ID
 
         :returns: the document or None
         :rtype: Element | None
         """
+        doc_id = _get_doc_id(doc_id, eid)
 
         # Cannot use process_elements here because we want to return a
         # specific document
 
-        if eid is not None:
+        if doc_id is not None:
             # Document specified by ID
-            return self._read().get(eid, None)
+            return self._read().get(doc_id, None)
 
         # Document specified by condition
         for doc in self.all():
@@ -479,7 +517,7 @@ class Table(object):
 
         return len(self.search(cond))
 
-    def contains(self, cond=None, eids=None):
+    def contains(self, cond=None, doc_ids=None, eids=None):
         """
         Check wether the database contains a document matching a condition or
         an ID.
@@ -489,12 +527,13 @@ class Table(object):
 
         :param cond: the condition use
         :type cond: Query
-        :param eids: the document IDs to look for
+        :param doc_ids: the document IDs to look for
         """
+        doc_ids = _get_doc_ids(doc_ids, eids)
 
-        if eids is not None:
+        if doc_ids is not None:
             # Documents specified by ID
-            return any(self.get(eid=eid) for eid in eids)
+            return any(self.get(doc_id=doc_id) for doc_id in doc_ids)
 
         # Document specified by condition
         return self.get(cond) is not None

--- a/tinydb/operations.py
+++ b/tinydb/operations.py
@@ -1,54 +1,58 @@
 def delete(field):
     """
-    Delete a given field from the element.
+    Delete a given field from the document.
     """
-    def transform(element):
-        del element[field]
+    def transform(doc):
+        del doc[field]
 
     return transform
+
 
 def add(field, n):
     """
-    Add n to a given field in the element.
+    Add n to a given field in the document.
     """
-    def transform(element):
-        element[field] += n
+    def transform(doc):
+        doc[field] += n
 
     return transform
+
 
 def subtract(field, n):
     """
-    Subtract n from a given field in the element.
+    Subtract n from a given field in the document.
     """
-    def transform(element):
-        element[field] -= n
+    def transform(doc):
+        doc[field] -= n
 
     return transform
+
 
 def set(field, val):
     """
     Set a given field to val.
     """
-    def transform(element):
-        element[field] = val
+    def transform(doc):
+        doc[field] = val
 
     return transform
 
+
 def increment(field):
     """
-    Increment a given field in the element.
+    Increment a given field in the document.
     """
-    def transform(element):
-        element[field] += 1
+    def transform(doc):
+        doc[field] += 1
 
     return transform
 
 
 def decrement(field):
     """
-    Decrement a given field in the element.
+    Decrement a given field in the document.
     """
-    def transform(element):
-        element[field] -= 1
+    def transform(doc):
+        doc[field] -= 1
 
     return transform

--- a/tinydb/queries.py
+++ b/tinydb/queries.py
@@ -99,8 +99,8 @@ class Query(object):
     >>> db.search(where('field1').exists() | where('field2') == 5)  # Binary OR
 
     Queries are executed by calling the resulting object. They expect to get the
-    element to test as the first argument and return ``True`` or ``False``
-    depending on whether the elements matches the query or not.
+    document to test as the first argument and return ``True`` or ``False``
+    depending on whether the documents matches the query or not.
     """
 
     def __init__(self):
@@ -273,7 +273,7 @@ class Query(object):
 
     def any(self, cond):
         """
-        Checks if a condition is met by any element in a list,
+        Checks if a condition is met by any document in a list,
         where a condition can also be a sequence (e.g. list).
 
         >>> Query().f1.any(Query().f2 == 1)
@@ -283,16 +283,15 @@ class Query(object):
             {'f1': [{'f2': 1}, {'f2': 0}]}
 
         >>> Query().f1.any([1, 2, 3])
-        # Match f1 that contains any element from [1, 2, 3]
 
         Matches::
 
             {'f1': [1, 2]}
             {'f1': [3, 4, 5]}
 
-        :param cond: Either a query that at least one element has to match or
-                     a list of which at least one element has to be contained
-                     in the tested element.
+        :param cond: Either a query that at least one document has to match or
+                     a list of which at least one document has to be contained
+                     in the tested document.
 -       """
         if callable(cond):
             def _cmp(value):
@@ -307,7 +306,7 @@ class Query(object):
 
     def all(self, cond):
         """
-        Checks if a condition is met by any element in a list,
+        Checks if a condition is met by any document in a list,
         where a condition can also be a sequence (e.g. list).
 
         >>> Query().f1.all(Query().f2 == 1)
@@ -317,14 +316,13 @@ class Query(object):
             {'f1': [{'f2': 1}, {'f2': 1}]}
 
         >>> Query().f1.all([1, 2, 3])
-        # Match f1 that contains any element from [1, 2, 3]
 
         Matches::
 
             {'f1': [1, 2, 3, 4, 5]}
 
-        :param cond: Either a query that all elements have to match or a list
-                     which has to be contained in the tested element.
+        :param cond: Either a query that all documents have to match or a list
+                     which has to be contained in the tested document.
         """
         if callable(cond):
             def _cmp(value):

--- a/tinydb/queries.py
+++ b/tinydb/queries.py
@@ -95,12 +95,12 @@ class Query(object):
     Besides the methods documented here you can combine queries using the
     binary AND and OR operators:
 
-    >>> db.search(where('field1').exists() & where('field2') == 5)  # Binary AND
-    >>> db.search(where('field1').exists() | where('field2') == 5)  # Binary OR
+    >>> db.search(where('field1').exists() & where('field2') == 5) # Binary AND
+    >>> db.search(where('field1').exists() | where('field2') == 5) # Binary OR
 
-    Queries are executed by calling the resulting object. They expect to get the
-    document to test as the first argument and return ``True`` or ``False``
-    depending on whether the documents matches the query or not.
+    Queries are executed by calling the resulting object. They expect to get
+    the document to test as the first argument and return ``True`` or
+    ``False`` depending on whether the documents matches the query or not.
     """
 
     def __init__(self):


### PR DESCRIPTION
TinyDB is a document-oriented database. Yet, since the the initial commit (b01cf23013c745c551f6bdffc78d737bf8e5f1f2) we used the term _elements_ instead of _documents_ for the database entries. I think it's actually a kind of weird and awkward term, so this PR would rename all usages of `element` to `document`.

Now, this is mostly a documentation change. But we also have a wrapper class called `Element` and also use `eid` to refer to element/documen IDs. My question: is it worth the hassle to have a new breaking change along with a major version bump (v4.0.0) to rename these usages too? We'd then have a `Document` class and refer to IDs as document IDs/`doc_id`.

@eugene-eeo Do you have any insight on this?