### PR TITLE
Convert dump data to raw dictionary in YAMLStorage

### DIFF
--- a/docs/extend.rst
+++ b/docs/extend.rst
@@ -35,7 +35,7 @@ Let's look how you could add a `YAML <http://yaml.org/>`_ storage using
 
         def write(self, data):
             with open(self.filename, 'w') as handle:
-                yaml.dump(data, handle)
+                yaml.dump(yaml.safe_load(str(data)), handle)
 
         def close(self):  # (4)
             pass


### PR DESCRIPTION
Previously, dump was causing the python object to get
dumped instead of the raw dictionary itself.

As a result upon issuing a db.update({'name': 'foo'}) call, the entry would change to:

1: !!python/object/new:tinydb.database.Document
    dictitems: {name: foo}
    state: {doc_id: 1}

Instead of:

1: {name: foo}

Not sure if this is the proper fix, but it seems to work.

Another person described the same issue here:
https://gist.github.com/fndari/bc4d724a52c9d4b1152ea1a2e5a5ffed