### PR TITLE
Corrected URL and status of TinyMP to be identical to README

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -23,8 +23,8 @@ Here are some extensions that might be useful to you:
 ``TinyMP``
 *************
 
-| **Repo:**        https://github.com/schapman1974/tinymongo
-| **Status:**      *experimental*
+| **Repo:**        https://github.com/alshapton/TinyMP
+| **Status:**      *stable*
 | **Description:** A MessagePack-based storage extension to tinydb using
                    http://msgpack.org
 


### PR DESCRIPTION
The information for TinyMP was incorrect. This PR corrects it.