### PR TITLE
Search inside the list type value as well

### DIFF
--- a/tinydb/queries.py
+++ b/tinydb/queries.py
@@ -147,7 +147,7 @@ class Query(object):
         """
         if sys.version_info <= (3, 0):  # pragma: no cover
             # Special UTF-8 handling on Python 2
-            def test(value):
+            def _unicode_test(value):
                 with catch_warning(UnicodeWarning):
                     try:
                         return value == rhs
@@ -159,9 +159,22 @@ class Query(object):
                         elif isinstance(rhs, str):
                             return value == rhs.decode('utf-8')
 
+            def test(value):
+                if isinstance(value, list):
+                    for val in value:
+                        if _unicode_test(val):
+                            return True
+                else:
+                    return _unicode_test(value)
+
         else:  # pragma: no cover
             def test(value):
-                return value == rhs
+                if isinstance(value, list):
+                    for val in value:
+                        if val == rhs:
+                            return True
+                else:
+                    return value == rhs
 
         return self._generate_test(lambda value: test(value),
                                    ('==', tuple(self._path), freeze(rhs)))


### PR DESCRIPTION
Example case:
```python
from tinydb import TinyDB, Query
from tinydb.storages import MemoryStorage
db = TinyDB(storage=MemoryStorage)
db.insert({
    "user_name": "bob",
    "tag": [
        "Rich",
        "Male",
        "Smart",
    ]
})
db.insert({
    "user_name": "alice",
    "tag": "Smart",
})

table = db.table('_default')
User = Query()
result = table.search(User.tag == "Smart")
print(len(result))

# result: 1
```

Currently it simply compare with value, did not consider value is a list or not.
In the other hand, MongoDB does that, maybe TinyDB could support that, too?

Made a change in `Query` object to achieve that,
and the result from example above should return `2`




