### PR TITLE
Add Table.write_back(), replacing documents by ids

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 from distutils.util import convert_path
 from setuptools import setup, find_packages
 from codecs import open
+import sys
 import os
 
 
@@ -46,7 +47,9 @@ setup(
         "Operating System :: OS Independent"
     ],
     tests_require=['pytest-cov'],
-    setup_requires=['pytest-runner'],
+    # a temporary workaround for pytest-runner keep failing
+    # to find package in python 2.6
+    setup_requires=[] if sys.version < '2.7' else ['pytest-runner'],
 
     long_description=read('README.rst'),
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 from setuptools import setup, find_packages
 from codecs import open
-import sys
 import os
 
 
@@ -48,9 +47,7 @@ setup(
         "Operating System :: OS Independent"
     ],
     tests_require=['pytest-cov'],
-    # a temporary workaround for pytest-runner keep failing
-    # to find package in python 2.6
-    setup_requires=[] if sys.version < '2.7' else ['pytest-runner'],
+    setup_requires=['pytest-runner'],
 
     long_description=read('README.rst'),
 )

--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -206,6 +206,13 @@ def test_replace_fails(db):
         db.replace([{'get': 'error'}], [1, 2])
 
 
+def test_replace_id_exceed(db):
+    db.purge()
+    db.insert({'int': 1})
+    with pytest.raises(IndexError):
+        db.replace([{'get': 'error'}], [2])
+
+
 def test_upsert(db):
     assert len(db) == 3
 

--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -189,9 +189,9 @@ def test_replace_whole_doc(db):
         docs[i] = {'newField': i}
 
     db.replace(docs, doc_ids)
+    assert db.count(where('newField') == 0) == 1
     assert db.count(where('newField') == 1) == 1
     assert db.count(where('newField') == 2) == 1
-    assert db.count(where('newField') == 3) == 1
 
 
 def test_upsert(db):

--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -194,6 +194,13 @@ def test_replace_whole_doc(db):
     assert db.count(where('newField') == 2) == 1
 
 
+def test_replace_returns_ids(db):
+    db.purge()
+    assert db.insert({'int': 1, 'char': 'a'}) == 1
+    assert db.insert({'int': 1, 'char': 'a'}) == 2
+    assert db.replace([{'word': 'hello'}, {'word': 'world'}], [1, 2]) == [1, 2]
+
+
 def test_upsert(db):
     assert len(db) == 3
 

--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -173,6 +173,27 @@ def test_update_ids(db):
     assert db.count(where('int') == 2) == 2
 
 
+def test_replace(db):
+    docs = db.search(where('int') == 1)
+    for doc in docs:
+        doc['int'] = [1, 2, 3]
+
+    db.replace(docs)
+    assert db.count(where('int') == [1, 2, 3]) == 3
+
+
+def test_replace_whole_doc(db):
+    docs = db.search(where('int') == 1)
+    doc_ids = [doc.doc_id for doc in docs]
+    for i, doc in enumerate(docs):
+        docs[i] = {'newField': i}
+
+    db.replace(docs, doc_ids)
+    assert db.count(where('newField') == 1) == 1
+    assert db.count(where('newField') == 2) == 1
+    assert db.count(where('newField') == 3) == 1
+
+
 def test_upsert(db):
     assert len(db) == 3
 

--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -173,44 +173,44 @@ def test_update_ids(db):
     assert db.count(where('int') == 2) == 2
 
 
-def test_replace(db):
+def test_write_back(db):
     docs = db.search(where('int') == 1)
     for doc in docs:
         doc['int'] = [1, 2, 3]
 
-    db.replace(docs)
+    db.write_back(docs)
     assert db.count(where('int') == [1, 2, 3]) == 3
 
 
-def test_replace_whole_doc(db):
+def test_write_back_whole_doc(db):
     docs = db.search(where('int') == 1)
     doc_ids = [doc.doc_id for doc in docs]
     for i, doc in enumerate(docs):
         docs[i] = {'newField': i}
 
-    db.replace(docs, doc_ids)
+    db.write_back(docs, doc_ids)
     assert db.count(where('newField') == 0) == 1
     assert db.count(where('newField') == 1) == 1
     assert db.count(where('newField') == 2) == 1
 
 
-def test_replace_returns_ids(db):
+def test_write_back_returns_ids(db):
     db.purge()
     assert db.insert({'int': 1, 'char': 'a'}) == 1
     assert db.insert({'int': 1, 'char': 'a'}) == 2
-    assert db.replace([{'word': 'hello'}, {'word': 'world'}], [1, 2]) == [1, 2]
+    assert db.write_back([{'word': 'hello'}, {'word': 'world'}], [1, 2]) == [1, 2]
 
 
-def test_replace_fails(db):
+def test_write_back_fails(db):
     with pytest.raises(ValueError):
-        db.replace([{'get': 'error'}], [1, 2])
+        db.write_back([{'get': 'error'}], [1, 2])
 
 
-def test_replace_id_exceed(db):
+def test_write_back_id_exceed(db):
     db.purge()
     db.insert({'int': 1})
     with pytest.raises(IndexError):
-        db.replace([{'get': 'error'}], [2])
+        db.write_back([{'get': 'error'}], [2])
 
 
 def test_upsert(db):

--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -201,6 +201,11 @@ def test_replace_returns_ids(db):
     assert db.replace([{'word': 'hello'}, {'word': 'world'}], [1, 2]) == [1, 2]
 
 
+def test_replace_fails(db):
+    with pytest.raises(ValueError):
+        db.replace([{'get': 'error'}], [1, 2])
+
+
 def test_upsert(db):
     assert len(db) == 3
 

--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -497,6 +497,13 @@ class Table(object):
         if doc_ids is None:
             doc_ids = [doc.doc_id for doc in documents]
 
+        # Since this function will write docs back like inserting, to ensure
+        # here only process existing or removed instead of inserting new,
+        # raise error if doc_id exceeded the last.
+        if sorted(doc_ids)[-1] > self._last_id:
+            raise IndexError(
+                'Id exceed table length, use existing or removed doc_id.')
+
         data = self._read()
 
         # Document specified by ID

--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -490,11 +490,14 @@ class Table(object):
         """
         doc_ids = _get_doc_ids(doc_ids, eids)
 
-        data = self._read()
-
-        if not len(documents) == len(doc_ids):
+        if doc_ids is not None and not len(documents) == len(doc_ids):
             raise ValueError(
                 'The length of documents and doc_ids is not match.')
+
+        if doc_ids is None:
+            doc_ids = [doc.doc_id for doc in documents]
+
+        data = self._read()
 
         # Document specified by ID
         documents.reverse()

--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -480,6 +480,31 @@ class Table(object):
                 cond, doc_ids
             )
 
+    def replace(self, documents, doc_ids=None, eids=None):
+        """
+        Replace documents by doc_id
+
+        :param documents: a list of document to replace
+        :param doc_ids: a list of documents' ID which needs to be replaced
+        :returns: a list of replaced documents' ID
+        """
+        doc_ids = _get_doc_ids(doc_ids, eids)
+
+        data = self._read()
+
+        if not len(documents) == len(doc_ids):
+            raise ValueError(
+                'The length of documents and doc_ids is not match.')
+
+        # Document specified by ID
+        documents.reverse()
+        for doc_id in doc_ids:
+            data[doc_id] = documents.pop()
+
+        self._write(data)
+
+        return doc_ids
+
     def upsert(self, document, cond):
         """
         Update a document, if it exist - insert it otherwise.

--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -480,13 +480,13 @@ class Table(object):
                 cond, doc_ids
             )
 
-    def replace(self, documents, doc_ids=None, eids=None):
+    def write_back(self, documents, doc_ids=None, eids=None):
         """
-        Replace documents by doc_id
+        Write back documents by doc_id
 
-        :param documents: a list of document to replace
-        :param doc_ids: a list of documents' ID which needs to be replaced
-        :returns: a list of replaced documents' ID
+        :param documents: a list of document to write back
+        :param doc_ids: a list of documents' ID which needs to be wrote back
+        :returns: a list of documents' ID taht has been wrote back
         """
         doc_ids = _get_doc_ids(doc_ids, eids)
 


### PR DESCRIPTION
Compare to `update()`, ~`replace()`~ `write_back()` provide a more customizable workflow
to modify documents.
One can fistly search the documents and modify them by thier conditions,
then input new douments with thier `doc_ids` to ~`replace()`~ `write_back()`.

### Example Usage
```python
from tinydb import TinyDB, Query
from tinydb.storages import MemoryStorage

db = TinyDB(storage=MemoryStorage)

db.purge()

dataset = [
    {"stock": ["cookies", "apple"]},
    {"stock": ["brownies"]},
    {"stock": ["cake"]},
    {"stock": ["cookies", "milk"]},
    {"stock": ["cake"]},
    {"stock": ["pie", "cake"]},
    {"stock": ["apple"]},
]

table = db.table('yumyum')
table.insert_multiple(dataset)
# search
yum = Query()
docs = table.search(yum.stock.any(["cake", "apple"]))
# modify docs
for doc in docs:
    for i, stock in enumerate(doc["stock"]):
        if stock == "cake":
            doc["stock"][i] = "water"
        if stock == "apple":
            doc["stock"][i] = "honey"
# write back
table.write_back(docs)
```

Or ~replace~ write_back with new documents
```python
db.purge()

table = db.table('yumyum')
table.insert_multiple(dataset)

docs = table.all()
# save doc_ids
doc_ids = [doc.doc_id for doc in docs]
# modify docs
for i, doc in enumerate(docs):
    if len(doc["stock"]) == 1:
        docs[i] = {"best": doc["stock"][0]}
    elif len(doc["stock"]) > 1:
        docs[i] = {"good": doc["stock"]}

table.write_back(docs, doc_ids)
```

Could be a convenient feature :)
