### PR TITLE
Fix 0 capacity issue. now cache_size can be 0

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -45,6 +45,17 @@ def test_caching(db):
 
     assert table1 is table2
 
+def test_zero_cache_size(db):
+    table = db.table('table3', cache_size=0)
+    query = where('int') == 1
+
+    table.insert({'int': 1})
+    table.insert({'int': 1})
+
+    assert table.count(query) == 2
+    assert table.count(where('int') == 2) == 0
+    assert len(table._query_cache) == 0
+
 
 def test_query_cache_size(db):
     table = db.table('table3', cache_size=1)

--- a/tinydb/utils.py
+++ b/tinydb/utils.py
@@ -21,7 +21,10 @@ class LRUCache(dict):
                          or ``None`` for an unlimited cache size
         """
 
-        self.capacity = kwargs.pop('capacity', None) or float('nan')
+        self.capacity = kwargs.pop('capacity', None)
+        if self.capacity is None:
+            self.capacity = float('nan')
+            
         self.lru = []
 
         super(LRUCache, self).__init__(*args, **kwargs)


### PR DESCRIPTION
I encountered a problem while setting cache_size to 0. The result was an unlimited cache because in python "0" evaluates to false. This PR would fix this.

kind regards