### PR TITLE
Fix bug in write_back

### DIFF
--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -213,6 +213,10 @@ def test_write_back_id_exceed(db):
         db.write_back([{'get': 'error'}], [2])
 
 
+def test_write_back_empty_ok(db):
+    db.write_back([])
+
+
 def test_upsert(db):
     assert len(db) == 3
 

--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -485,8 +485,8 @@ class Table(object):
         Write back documents by doc_id
 
         :param documents: a list of document to write back
-        :param doc_ids: a list of documents' ID which needs to be wrote back
-        :returns: a list of documents' ID taht has been wrote back
+        :param doc_ids: a list of documents' ID which need to be wrote back
+        :returns: a list of documents' ID that have been written
         """
         doc_ids = _get_doc_ids(doc_ids, eids)
 
@@ -502,7 +502,7 @@ class Table(object):
         # raise error if doc_id exceeded the last.
         if len(doc_ids) > 0 and max(doc_ids) > self._last_id:
             raise IndexError(
-                'Id exceed table length, use existing or removed doc_id.')
+                'ID exceeds table length, use existing or removed doc_id.')
 
         data = self._read()
 

--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -500,7 +500,7 @@ class Table(object):
         # Since this function will write docs back like inserting, to ensure
         # here only process existing or removed instead of inserting new,
         # raise error if doc_id exceeded the last.
-        if sorted(doc_ids)[-1] > self._last_id:
+        if len(doc_ids) > 0 and max(doc_ids) > self._last_id:
             raise IndexError(
                 'Id exceed table length, use existing or removed doc_id.')
 


### PR DESCRIPTION
 - Fixes a bug in `write_back(items)` – it will no longer raise an error if `items` is empty.
 - Make error detection `O(n)` – no longer sort the `doc_ids` array only to retrieve the last element, just take the maximum element instead.