### PR TITLE
Implement __repr__ methods for classes TinyDb, Table, Query etc.

### DIFF
--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -253,6 +253,14 @@ class TinyDB(object):
         """
         return self._table.__iter__()
 
+    def __repr__(self):
+        return "TinyDB ({} table{}, {})".format(
+            len(self._table_cache),
+            "" if len(self._table_cache) == 1 else "s",
+            self._storage
+            #type(self._storage).__name__
+        )
+
 
 class Table(object):
     """
@@ -630,6 +638,13 @@ class Table(object):
 
         # Document specified by condition
         return self.get(cond) is not None
+
+    def __repr__(self):
+        return "{} ({} entr{})".format(
+            self.name,
+            len(self),
+            "y" if len(self) == 1 else "ies"
+        )
 
 
 # Set the default table class

--- a/tinydb/queries.py
+++ b/tinydb/queries.py
@@ -371,6 +371,9 @@ class Query(object):
             ('one_of', tuple(self._path), freeze(items))
         )
 
+    def __repr__(self):
+        return 'Query{}'.format("".join(f"['{part}']" for part in self._path))
+
 
 def where(key):
     return Query()[key]

--- a/tinydb/storages.py
+++ b/tinydb/storages.py
@@ -69,6 +69,10 @@ class Storage(with_metaclass(ABCMeta, object)):
 
         pass
 
+    @classmethod
+    def __repr__(cls):
+        return cls.__name__
+
 
 class JSONStorage(Storage):
     """


### PR DESCRIPTION
Added `__repr__` methods for classes TinyDB, Table, Query and Storage:

```python
>>> from tinydb import TinyDB, Query
>>> from tinydb.storages import MemoryStorage
>>> db = TinyDB(storage=MemoryStorage)
>>> db.tables()
{'_default'}
>>> db # TinyDB.__repr__(), Storage.__repr__()
TinyDB (1 table, MemoryStorage)
>>> db.insert({'type': 'apple', 'skin': {'texture': 'soft', 'color': 'red'}})
1
>>> db.insert({'type': 'peach', 'skin': {'texture': 'soft', 'color': 'pink'}})
2
>>> db.table() # Table.__repr__()
_default (2 entries)
>>> table = db.table("dogs")
>>> table
dogs (0 entries)
>>> Fruit = Query()
>>> Fruit.skin['texture'] # Query.__repr__()
Query['skin']['texture']
```