### PR TITLE
opt: use OrderedDict to make LRUCache to optimize efficiency of set o…

### DIFF
--- a/tinydb/utils.py
+++ b/tinydb/utils.py
@@ -13,18 +13,26 @@ itervalues = getattr(dict, 'itervalues', dict.values)
 
 class LRUCache:
     # @param capacity, an integer
-    def __init__(self, capacity=0):
+    def __init__(self, capacity=None):
         self.capacity = capacity
-        self.length = 0
         self.__cache = OrderedDict()
 
     @property
     def lru(self):
         return list(self.__cache.keys())
 
+    @property
+    def length(self):
+        return len(self.__cache)
+
     def clear(self):
-        self.__cache = OrderedDict()
-        self.capacity = self.length = 0
+        self.__cache.clear()
+
+    def __len__(self):
+        return self.length
+
+    def __contains__(self, item):
+        return item in self.__cache
 
     def __setitem__(self, key, value):
         self.set(key, value)
@@ -48,11 +56,12 @@ class LRUCache:
             del self.__cache[key]
             self.__cache[key] = value
         else:
-            if self.length == self.capacity and self.length > 0:
-                self.__cache.popitem(last=False)
-                self.length -= 1
             self.__cache[key] = value
-            self.length += 1
+            # Check, if the cache is full and we have to remove old items
+            # If the queue is of unlimited size, self.capacity is NaN and
+            # x > NaN is always False in Python and the cache won't be cleared.
+            if self.capacity is not None and self.length > self.capacity:
+                self.__cache.popitem(last=False)
 
 
 # Source: https://github.com/PythonCharmers/python-future/blob/466bfb2dfa36d865285dc31fe2b0c0a53ff0f181/future/utils/__init__.py#L102-L134


### PR DESCRIPTION
## background
I found out that `if key in self.lru` (which is O(n)) judgement is used in `LRUCache.refresh` function and that will get much slower when there are more things cached

## change
 I try to use `OrderedDict` to make a new LRUCache class, so that both `set` or `get` operation will be O(1)

## benchmark
### conclusion
```
CacheType: <class '__main__.OrderedDictLRUCache'>
total_items:  10000
test_set: 10000 opts cost: 0.006773948669433594 s average: 677.3948669433594 ns/opt
CacheType: <class '__main__.LRUCache'>
total_items:  10000
test_set: 10000 opts cost: 0.44385218620300293 s average: 44385.21862030029 ns/opt
```

```
CacheType: <class '__main__.OrderedDictLRUCache'>
total_items:  50000
test_set: 50000 opts cost: 0.044634342193603516 s average: 892.6868438720703 ns/opt
CacheType: <class '__main__.LRUCache'>
total_items:  50000
test_set: 50000 opts cost: 10.979907274246216 s average: 219598.14548492432 ns/opt
```

### script
```Python
import time
from collections import OrderedDict


class OrderedDictLRUCache:
    # @param capacity, an integer
    def __init__(self, capacity=0):
        self.capacity = capacity
        self.length = 0
        self.__cache = OrderedDict()

    @property
    def lru(self):
        return list(self.__cache.keys())

    def clear(self):
        self.__cache = OrderedDict()
        self.capacity = self.length = 0

    def __setitem__(self, key, value):
        self.set(key, value)

    def __delitem__(self, key):
        del self.__cache[key]

    def __getitem__(self, key):
        return self.get(key)

    def get(self, key, default=None):
        value = self.__cache.get(key)
        if value:
            del self.__cache[key]
            self.__cache[key] = value
            return value
        return default

    def set(self, key, value):
        if self.__cache.get(key):
            del self.__cache[key]
            self.__cache[key] = value
        else:
            if self.length == self.capacity and self.length > 0:
                self.__cache.popitem(last=False)
                self.length -= 1
            self.__cache[key] = value
            self.length += 1


class LRUCache(dict):
    """
    A simple LRU cache.
    """

    def __init__(self, *args, **kwargs):
        """
        :param capacity: How many items to store before cleaning up old items
                         or ``None`` for an unlimited cache size
        """

        self.capacity = kwargs.pop('capacity', None)
        if self.capacity is None:
            self.capacity = float('nan')

        self.lru = []

        super(LRUCache, self).__init__(*args, **kwargs)

    def refresh(self, key):
        """
        Push a key to the tail of the LRU queue
        """
        if key in self.lru:
            self.lru.remove(key)
        self.lru.append(key)

    def get(self, key, default=None):
        item = super(LRUCache, self).get(key, default)
        self.refresh(key)

        return item

    def __getitem__(self, key):
        item = super(LRUCache, self).__getitem__(key)
        self.refresh(key)

        return item

    def __setitem__(self, key, value):
        super(LRUCache, self).__setitem__(key, value)

        self.refresh(key)

        # Check, if the cache is full and we have to remove old items
        # If the queue is of unlimited size, self.capacity is NaN and
        # x > NaN is always False in Python and the cache won't be cleared.
        if len(self) > self.capacity:
            self.pop(self.lru.pop(0))

    def __delitem__(self, key):
        super(LRUCache, self).__delitem__(key)
        self.lru.remove(key)

    def clear(self):
        super(LRUCache, self).clear()
        del self.lru[:]


if __name__ == '__main__':
    count_items = 10000
    cache = OrderedDictLRUCache(capacity=count_items)
    cache1 = LRUCache(capacity=count_items)


    def test_set(cache_obj):
        start = time.time()
        for idx in range(count_items):
            cache_obj[idx] = idx
        end = time.time()
        print('CacheType: {}'.format(type(cache_obj)))
        print('total_items: ', count_items)
        print('test_set: {} opts cost: {} s average: {} ns/opt'.format(count_items, end - start,
                                                                       (end - start) * pow(10, 9) / count_items))
        cache_obj.clear()


    test_set(cache)
    test_set(cache1)

```
