### PR TITLE
Add encoding option + fixed test that fails on windows.

### DIFF
--- a/tests/test_storages.py
+++ b/tests/test_storages.py
@@ -1,6 +1,7 @@
 import os
 import random
 import tempfile
+import json
 
 import pytest
 
@@ -233,3 +234,18 @@ def test_yaml(tmpdir):
 
     assert db.contains(where('name') == 'foo')
     assert len(db) == 1
+
+
+def test_encoding(tmpdir):
+    japanese_doc = {"Test": "こんにちは世界"}
+
+    path = str(tmpdir.join('test.db'))
+    jap_storage = JSONStorage(path, encoding="cp936")  # cp936 is used for japanese encodings
+    jap_storage.write(japanese_doc)
+
+    with pytest.raises(json.decoder.JSONDecodeError):
+        eng_storage = JSONStorage(path, encoding="cp037")  # cp037 is used for english encodings
+        eng_storage.read()
+
+    jap_storage = JSONStorage(path, encoding="cp936")
+    assert japanese_doc == jap_storage.read()

--- a/tests/test_storages.py
+++ b/tests/test_storages.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 import random
 import tempfile
@@ -237,7 +239,7 @@ def test_yaml(tmpdir):
 
 
 def test_encoding(tmpdir):
-    japanese_doc = {"Test": "こんにちは世界"}
+    japanese_doc = {"Test": u"こんにちは世界"}
 
     path = str(tmpdir.join('test.db'))
     jap_storage = JSONStorage(path, encoding="cp936")  # cp936 is used for japanese encodings

--- a/tests/test_storages.py
+++ b/tests/test_storages.py
@@ -243,7 +243,12 @@ def test_encoding(tmpdir):
     jap_storage = JSONStorage(path, encoding="cp936")  # cp936 is used for japanese encodings
     jap_storage.write(japanese_doc)
 
-    with pytest.raises(json.decoder.JSONDecodeError):
+    try:
+        exception = json.decoder.JSONDecodeError
+    except AttributeError:
+        exception = ValueError
+
+    with pytest.raises(exception):
         eng_storage = JSONStorage(path, encoding="cp037")  # cp037 is used for english encodings
         eng_storage.read()
 

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -111,8 +111,9 @@ def test_table_name(db):
 def test_table_repr(db):
     name = 'table4'
     table = db.table(name)
+    print(repr(table))
 
     assert re.match(
         r"<Table name=\'table4\', total=0, "
-        "storage=<tinydb\.database\.StorageProxy object at [a-z0-9]+>>",
+        "storage=<tinydb\.database\.StorageProxy object at [a-zA-Z0-9]+>>",
         repr(table))

--- a/tinydb/storages.py
+++ b/tinydb/storages.py
@@ -75,7 +75,7 @@ class JSONStorage(Storage):
     Store the data in a JSON file.
     """
 
-    def __init__(self, path, create_dirs=False, encoding: str=None, **kwargs):
+    def __init__(self, path, create_dirs=False, encoding=None, **kwargs):
         """
         Create a new instance.
 

--- a/tinydb/storages.py
+++ b/tinydb/storages.py
@@ -4,9 +4,8 @@ implementations.
 """
 
 from abc import ABCMeta, abstractmethod
-import io
+import codecs
 import os
-import sys
 
 from .utils import with_metaclass
 
@@ -90,7 +89,7 @@ class JSONStorage(Storage):
         super(JSONStorage, self).__init__()
         touch(path, create_dirs=create_dirs)  # Create file if not exists
         self.kwargs = kwargs
-        self._handle = io.open(path, 'r+', encoding=encoding)
+        self._handle = codecs.open(path, 'r+', encoding=encoding)
 
     def close(self):
         self._handle.close()
@@ -110,8 +109,6 @@ class JSONStorage(Storage):
     def write(self, data):
         self._handle.seek(0)
         serialized = json.dumps(data, **self.kwargs)
-        if sys.version_info[0] == 2:
-            serialized = unicode(serialized)
         self._handle.write(serialized)
         self._handle.flush()
         os.fsync(self._handle.fileno())

--- a/tinydb/storages.py
+++ b/tinydb/storages.py
@@ -6,6 +6,7 @@ implementations.
 from abc import ABCMeta, abstractmethod
 import io
 import os
+import sys
 
 from .utils import with_metaclass
 
@@ -109,6 +110,8 @@ class JSONStorage(Storage):
     def write(self, data):
         self._handle.seek(0)
         serialized = json.dumps(data, **self.kwargs)
+        if sys.version_info[0] == 2:
+            serialized = unicode(serialized)
         self._handle.write(serialized)
         self._handle.flush()
         os.fsync(self._handle.fileno())

--- a/tinydb/storages.py
+++ b/tinydb/storages.py
@@ -4,6 +4,7 @@ implementations.
 """
 
 from abc import ABCMeta, abstractmethod
+import io
 import os
 
 from .utils import with_metaclass
@@ -88,7 +89,7 @@ class JSONStorage(Storage):
         super(JSONStorage, self).__init__()
         touch(path, create_dirs=create_dirs)  # Create file if not exists
         self.kwargs = kwargs
-        self._handle = open(path, 'r+', encoding=encoding)
+        self._handle = io.open(path, 'r+', encoding=encoding)
 
     def close(self):
         self._handle.close()

--- a/tinydb/storages.py
+++ b/tinydb/storages.py
@@ -75,7 +75,7 @@ class JSONStorage(Storage):
     Store the data in a JSON file.
     """
 
-    def __init__(self, path, create_dirs=False, **kwargs):
+    def __init__(self, path, create_dirs=False, encoding: str=None, **kwargs):
         """
         Create a new instance.
 
@@ -88,7 +88,7 @@ class JSONStorage(Storage):
         super(JSONStorage, self).__init__()
         touch(path, create_dirs=create_dirs)  # Create file if not exists
         self.kwargs = kwargs
-        self._handle = open(path, 'r+')
+        self._handle = open(path, 'r+', encoding=encoding)
 
     def close(self):
         self._handle.close()


### PR DESCRIPTION
To solve one of the issues presented in #222, the very simple option was allow the encodings kwarg to be passed in. I also added a test for it. After running the tests, I noticed `test_table_repr` failed. I believe this is because on linux based machines, it displays the memory location with lowercase letters, while windows uses uppercase and lowercase. 