### PR TITLE
Check if storage file exists before creating it to avoid needlessly altering mtime

### DIFF
--- a/tinydb/storages.py
+++ b/tinydb/storages.py
@@ -21,8 +21,9 @@ def touch(fname, create_dirs):
         if not os.path.exists(base_dir):
             os.makedirs(base_dir)
 
-    with open(fname, 'a'):
-        os.utime(fname, None)
+    if not os.path.exists(fname):
+        with open(fname, 'a'):
+            os.utime(fname, None)
 
 
 class Storage(with_metaclass(ABCMeta, object)):


### PR DESCRIPTION
Resolves an issue described in #235 where `JSONStorage` was altering the storage file modify time each time it was initialized. This PR introduces a preliminary check to see if the storage file exists before attempting to create it.