### PR TITLE
Use tuple literals instead of tuple class/constructor

### DIFF
--- a/tinydb/queries.py
+++ b/tinydb/queries.py
@@ -105,10 +105,10 @@ class Query(QueryImpl):
     """
 
     def __init__(self):
-        self._path = []
+        self._path = ()
         super(Query, self).__init__(
             self._prepare_test(lambda _: True),
-            ('path', tuple(self._path))
+            ('path', self._path)
         )
 
     def __repr__(self):
@@ -119,8 +119,8 @@ class Query(QueryImpl):
 
     def __getattr__(self, item):
         query = Query()
-        query._path = self._path + [item]
-        query.hashval = ('path', tuple(query._path))
+        query._path = self._path + (item, )
+        query.hashval = ('path', query._path)
 
         return query
 
@@ -180,7 +180,7 @@ class Query(QueryImpl):
 
         return self._generate_test(
             lambda value: test(value),
-            ('==', tuple(self._path), freeze(rhs))
+            ('==', self._path, freeze(rhs))
         )
 
     def __ne__(self, rhs):
@@ -193,7 +193,7 @@ class Query(QueryImpl):
         """
         return self._generate_test(
             lambda value: value != rhs,
-            ('!=', tuple(self._path), freeze(rhs))
+            ('!=', self._path, freeze(rhs))
         )
 
     def __lt__(self, rhs):
@@ -206,7 +206,7 @@ class Query(QueryImpl):
         """
         return self._generate_test(
             lambda value: value < rhs,
-            ('<', tuple(self._path), rhs)
+            ('<', self._path, rhs)
         )
 
     def __le__(self, rhs):
@@ -219,7 +219,7 @@ class Query(QueryImpl):
         """
         return self._generate_test(
             lambda value: value <= rhs,
-            ('<=', tuple(self._path), rhs)
+            ('<=', self._path, rhs)
         )
 
     def __gt__(self, rhs):
@@ -232,7 +232,7 @@ class Query(QueryImpl):
         """
         return self._generate_test(
             lambda value: value > rhs,
-            ('>', tuple(self._path), rhs)
+            ('>', self._path, rhs)
         )
 
     def __ge__(self, rhs):
@@ -245,7 +245,7 @@ class Query(QueryImpl):
         """
         return self._generate_test(
             lambda value: value >= rhs,
-            ('>=', tuple(self._path), rhs)
+            ('>=', self._path, rhs)
         )
 
     def exists(self):
@@ -256,7 +256,7 @@ class Query(QueryImpl):
         """
         return self._generate_test(
             lambda _: True,
-            ('exists', tuple(self._path))
+            ('exists', self._path)
         )
 
     def matches(self, regex, flags=0):
@@ -269,7 +269,7 @@ class Query(QueryImpl):
         """
         return self._generate_test(
             lambda value: re.match(regex, value, flags),
-            ('matches', tuple(self._path), regex)
+            ('matches', self._path, regex)
         )
 
     def search(self, regex, flags=0):
@@ -283,7 +283,7 @@ class Query(QueryImpl):
         """
         return self._generate_test(
             lambda value: re.search(regex, value, flags),
-            ('search', tuple(self._path), regex)
+            ('search', self._path, regex)
         )
 
     def test(self, func, *args):
@@ -301,7 +301,7 @@ class Query(QueryImpl):
         """
         return self._generate_test(
             lambda value: func(value, *args),
-            ('test', tuple(self._path), func, args)
+            ('test', self._path, func, args)
         )
 
     def any(self, cond):
@@ -336,7 +336,7 @@ class Query(QueryImpl):
 
         return self._generate_test(
             lambda value: _cmp(value),
-            ('any', tuple(self._path), freeze(cond))
+            ('any', self._path, freeze(cond))
         )
 
     def all(self, cond):
@@ -369,7 +369,7 @@ class Query(QueryImpl):
 
         return self._generate_test(
             lambda value: _cmp(value),
-            ('all', tuple(self._path), freeze(cond))
+            ('all', self._path, freeze(cond))
         )
 
     def one_of(self, items):
@@ -382,7 +382,7 @@ class Query(QueryImpl):
         """
         return self._generate_test(
             lambda value: value in items,
-            ('one_of', tuple(self._path), freeze(items))
+            ('one_of', self._path, freeze(items))
         )
 
 


### PR DESCRIPTION
This can be a micro optimization (blind guess I was not done any measurements) because `tuple` name will not be looked in the global scope and also there will not be extra function call.