### PR TITLE
Memoize DataProxy in StorageProxy.read

### DIFF
--- a/tests/test_storages.py
+++ b/tests/test_storages.py
@@ -162,13 +162,13 @@ def test_read_once():
         reset_counter()
 
         db.all()
-        reset_counter()
+        reset_counter(expected=0)
 
         db.insert({'foo': 'bar'})
-        reset_counter()
+        reset_counter(expected=0)
 
         db.all()
-        reset_counter()
+        reset_counter(expected=1)
 
 
 def test_custom_with_exception():


### PR DESCRIPTION
fixes #250

Resulting performance on repeated reads:

```
>>> from performance import *
>>> benchmark()
Reads on db: 0.00020786002278327942
Reads on table: 0.00018658797489479184
Reads on dict: 0.00013428402598947287
```

(see script in #250)