### PR TITLE
Fix Query class to permit subclass creation

### DIFF
--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -366,17 +366,17 @@ def test_repr():
 
 
 def test_subclass():
+    # Test that a new query test method in a custom subclass is properly usable
     class MyQueryClass(Query):
-        def my_search(self, regex):
+        def equal_double(self, rhs):
             return self._generate_test(
-            lambda value: re.search(regex, value),
-            ('search', self._path, regex)
+            lambda value: value == rhs*2,
+            ('equal_double', self._path, rhs)
         )
 
-    query = MyQueryClass().val.my_search(r'\d{2}\.')
+    query = MyQueryClass().val.equal_double('42')
 
-    assert query({'val': '42.'})
-    assert not query({'val': '44'})
-    assert not query({'val': 'ab.'})
+    assert query({'val': '4242'})
+    assert not query({'val': '42'})
     assert not query({'': None})
     assert hash(query)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -363,3 +363,20 @@ def test_repr():
 
     assert repr(Fruit) == "Query()"
     assert repr(Fruit.type == 'peach') == "QueryImpl('==', ('type',), 'peach')"
+
+
+def test_subclass():
+    class MyQueryClass(Query):
+        def my_search(self, regex):
+            return self._generate_test(
+            lambda value: re.search(regex, value),
+            ('search', self._path, regex)
+        )
+
+    query = MyQueryClass().val.my_search(r'\d{2}\.')
+
+    assert query({'val': '42.'})
+    assert not query({'val': '44'})
+    assert not query({'val': 'ab.'})
+    assert not query({'': None})
+    assert hash(query)

--- a/tinydb/queries.py
+++ b/tinydb/queries.py
@@ -120,7 +120,7 @@ class Query(QueryImpl):
         return super(Query, self).__hash__()
 
     def __getattr__(self, item):
-        query = Query()
+        query = type(self)()
         query._path = self._path + (item, )
         query.hashval = ('path', query._path)
 


### PR DESCRIPTION
Creating a subclass of the Query class in order to implement custom queries currently fails because the __getattr__ method creates a new instance of the Query class using a hard-coded name rather than the type of the current instance.  This can easily be fixed by using `type(self)()` to create the new class instance.

Creating a new subclass of Query is useful in order to simplify code scenarios where custom test functions are frequently used.

This pull request provides both a test and a fix for this problem.