### PR TITLE
Fix DeprecationWarning due to unescaped sequence

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -115,5 +115,5 @@ def test_table_repr(db):
 
     assert re.match(
         r"<Table name=\'table4\', total=0, "
-        "storage=<tinydb\.database\.StorageProxy object at [a-zA-Z0-9]+>>",
+        r"storage=<tinydb\.database\.StorageProxy object at [a-zA-Z0-9]+>>",
         repr(table))


### PR DESCRIPTION
This fixes a `DeprecationWarning` in test in 3.6 and 3.7. It's now a `SyntaxWarning` in Python 3.8 . 

Warning : https://dev.azure.com/msiemens/github/_build/results?buildId=42&view=logs&jobId=19c563d8-3dcd-57d1-cd5e-9dd946b0a29b&taskId=10ebb82f-a000-5f8e-b96f-1ffc81828e7d&lineStart=159&lineEnd=160&colStart=1&colEnd=1

Thanks