### PR TITLE
Enable file access mode for JSONStorage

### DIFF
--- a/tests/test_storages.py
+++ b/tests/test_storages.py
@@ -79,6 +79,23 @@ def test_json_readwrite(tmpdir):
     db.close()
 
 
+def test_json_read(tmpdir):
+    r"""Open a database only for reading"""
+    path = str(tmpdir.join('test.db'))
+    with pytest.raises(FileNotFoundError):
+        db = TinyDB(path, storage=JSONStorage, access_mode='r')
+    # Create small database
+    db = TinyDB(path, storage=JSONStorage)
+    db.insert({'b': 1})
+    db.insert({'a': 1})
+    db.close()
+    # Access in read mode
+    db = TinyDB(path, storage=JSONStorage, access_mode='r')
+    with pytest.raises(IOError):
+        db.insert({'c': 1})
+    db.close()
+
+
 def test_create_dirs():
     temp_dir = tempfile.gettempdir()
 

--- a/tests/test_storages.py
+++ b/tests/test_storages.py
@@ -91,8 +91,9 @@ def test_json_read(tmpdir):
     db.close()
     # Access in read mode
     db = TinyDB(path, storage=JSONStorage, access_mode='r')
+    assert db.get(where('a') == 1) == {'a': 1}  # reading is fine
     with pytest.raises(IOError):
-        db.insert({'c': 1})
+        db.insert({'c': 1})  # writing is not
     db.close()
 
 


### PR DESCRIPTION
Work done:
- [x] Optional argument `access_mode` for `JSONStorage.__init__`
- [x] Unit test for reading-only access to a database

Refs #297 