### PR TITLE
Replace setup.py calls with pip

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,8 +57,8 @@ try:
     release = pkg_resources.get_distribution('tinydb').version
 except pkg_resources.DistributionNotFound:
     print('To build the documentation, The distribution information of TinyDB')
-    print('Has to be available. Either install the package into your')
-    print('development environment or run "setup.py develop" to setup the')
+    print('has to be available. Either install the package into your')
+    print('development environment or run "pip install -e ." to setup the')
     print('metadata. A virtualenv is recommended!')
     sys.exit(1)
 del pkg_resources

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -13,7 +13,7 @@ To install TinyDB from PyPI, run::
 You can also grab the latest development version from GitHub_. After downloading
 and unpacking it, you can install it using::
 
-    $ python setup.py install
+    $ pip install .
 
 
 Basic Usage


### PR DESCRIPTION
Fixes #312.

It's generally discouraged to call `python setup.py`, even if it exists.

Running `pip install .` should install TinyDB from source. As TinyDB switched from `setup.py` to `pyproject.toml`, it doesn't include a `setup.py` file in the source tree any more.
