### PR TITLE
Tiny change to pymongo url

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -18,7 +18,7 @@ Why Use TinyDB?
   fun to use by providing a simple and clean API.
 
 - **written in pure Python:** TinyDB neither needs an external server (as
-  e.g. `PyMongo <https://api.mongodb.org/python/current/>`_) nor any dependencies
+  e.g. `PyMongo <https://pymongo.readthedocs.io/en/stable/>`_) nor any dependencies
   from PyPI.
 
 - **works on Python 3.5+ and PyPy:** TinyDB works on all modern versions of Python


### PR DESCRIPTION
# Edit on the documentation

A *tiny* change in the documentation. It seems [pymongo](https://pymongo.readthedocs.io/) URL changed from `current` to `stable`. This pull request fixes the URL path given in the ìntro.md`.