### PR TITLE
modify tinydb.operations.py doc annotation err

### DIFF
--- a/tinydb/operations.py
+++ b/tinydb/operations.py
@@ -3,7 +3,7 @@ A collection of update operations for TinyDB.
 
 They are used for updates like this:
 
->>> db.update(delete('foo'), where('foo') == 2
+>>> db.update(delete('foo'), where('foo') == 2)
 
 This would delete the ``foo`` field from all documents where ``foo`` equals 2.
 """


### PR DESCRIPTION
Hello,

msiemens!
I see test case file `tests/test_operations.py` and doc `docs/usage.rst`.
The correct method to call is `db.update(delete('int'), where('char') == 'a')`.

API doc [link](https://tinydb.readthedocs.io/en/stable/api.html#module-tinydb.operations) is error. I initially thought it was something like keyword `assert`.

Thank you.