### PR TITLE
feat: Make tinydb PEP 561 compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Operating System :: OS Independent",
+    "Typing :: Typed",
 ]
 
 packages = [


### PR DESCRIPTION
[PEP 561](https://www.python.org/dev/peps/pep-0561/) defines a way to share type hints for Python packages.

As `tinydb` already provides type annotations for their modules, add last 2 pieces: `py.typed` file & PyPI classifier to allow `mypy` and other static analyzers use TinyDB type annotations.

---

First of all, thanks a lot for this beautiful piece of software! I'm enjoying use `tinydb` within my projects. 

However, as I recently restrict `mypy` config I start receiving errors such as,

```
src/app/contexts.py:5:1: error: Skipping analyzing 'tinydb': found module but no type hints or library stubs  [import]
src/app/contexts.py:5:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
```

With that in mind I propose to make `tinydb` package PEP 561 compatible, so `mypy` and other static analyzer users may benefit from `tinydb` type hints.

Thanks

ps. BTW, to fix the `mypy` issue above I'm using next config,

```ini
[mypy-tinydb.*]
ignore_missing_imports = True
```