### PR TITLE
Doc: Table missing in usage fixed

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -458,7 +458,8 @@ Let's sum up the way TinyDB supports working with IDs:
 +-------------------------------------+------------------------------------------------------------+
 | ``db.get(doc_id=...)``              | Get the document with the given ID                         |
 +-------------------------------------+------------------------------------------------------------+
-| ``db.contains(doc_id=...)``         | Check if the db contains a document with the given         |                                     | IDs                                                        |
+| ``db.contains(doc_id=...)``         | Check if the db contains a document with the given         |
+|                                     | IDs                                                        |
 +-------------------------------------+------------------------------------------------------------+
 | ``db.update({...}, doc_ids=[...])`` | Update all documents with the given IDs                    |
 +-------------------------------------+------------------------------------------------------------+


### PR DESCRIPTION
The table of using document ids was missing in usage.rst due to a missing line break