### PR TITLE
Update remaining reference to non-latest python version

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         poetry build
         twine check dist/*
-      if: ${{ contains(matrix.python-version, '3.9') }}
+      if: ${{ contains(matrix.python-version, '3.10') }}
     - name: Upload coverage result
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ projects on the `discussion forum <http://forum.m-siemens.de/.>`_.
 Supported Python Versions
 *************************
 
-TinyDB has been tested with Python 3.6 - 3.9 and PyPy3.
+TinyDB has been tested with Python 3.6 - 3.10 and PyPy3.
 
 Example Code
 ************


### PR DESCRIPTION
In a couple of places the "main" (latest) version was still 3.9, this updates them to 3.10