### PR TITLE
Support adding callables to path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,10 @@ Query Language
     >>> db.search((User.name == 'John') | (User.name == 'Bob'))
     [{'name': 'John', 'age': 22}, {'name': 'John', 'age': 37}, {'name': 'Bob', 'age': 42}]
 
+    >>> # Apply transformation to field with `map`
+    >>> db.search((User.age.map(lambda x: x + x) == 44))
+    >>> [{'name': 'John', 'age': 22}]
+
     >>> # More possible comparisons:  !=  <  >  <=  >=
     >>> # More possible checks: where(...).matches(regex), where(...).test(your_test_func)
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -52,6 +52,13 @@ identifier. In this case, you can switch to array indexing notation:
 >>> # Use this instead:
 >>> db.search(User['country-code'] == 'foo')
 
+In addition, you can use arbitrary transform function where a field would be,
+for example:
+
+>>> from unidecode import unidecode
+>>> db.search(User.name.map(unidecode) == 'Jose')
+>>> # will match 'José' etc.
+
 The second, traditional way of constructing queries is as follows:
 
 >>> from tinydb import where

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -42,6 +42,12 @@ def test_callable_in_path_with_map():
     assert not query({'value': 10})
 
 
+def test_callable_in_path_with_chain():
+    rekey = lambda x: {'y': x['a'], 'z': x['b']}
+    query = Query().map(rekey).z == 10
+    assert query({'a': 5, 'b': 10})
+
+
 def test_eq():
     query = Query().value == 1
     assert query({'value': 1})

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -35,6 +35,13 @@ def test_path_and():
     assert hash(query) != hash(where('value'))
 
 
+def test_callable_in_path_with_map():
+    double = lambda x: x + x
+    query = Query().value.map(double) == 10
+    assert query({'value': 5})
+    assert not query({'value': 10})
+
+
 def test_eq():
     query = Query().value == 1
     assert query({'value': 1})

--- a/tinydb/queries.py
+++ b/tinydb/queries.py
@@ -218,7 +218,10 @@ class Query(QueryInstance):
             try:
                 # Resolve the path
                 for part in self._path:
-                    value = value[part]
+                    if isinstance(part, str):
+                        value = value[part]
+                    else:
+                        value = part(value)
             except (KeyError, TypeError):
                 return False
             else:
@@ -487,6 +490,20 @@ class Query(QueryInstance):
             ()
         )
 
+    def map(self, fn: Callable[[Any], Any]) -> 'Query':
+        """
+        Add a function to the query path. Similar to __getattr__ but for
+        arbitrary functions.
+        """
+        query = type(self)()
+
+        # Now we add the callable to the query path ...
+        query._path = self._path + (fn,)
+
+        # ... and update the query hash
+        query._hash = ('path', query._path)
+
+        return query
 
 def where(key: str) -> Query:
     """

--- a/tinydb/table.py
+++ b/tinydb/table.py
@@ -232,8 +232,9 @@ class Table:
         # Perform the search by applying the query to all documents
         docs = [doc for doc in self if cond(doc)]
 
-        # Update the query cache
-        self._query_cache[cond] = docs[:]
+        if cond.is_cacheable():
+            # Update the query cache
+            self._query_cache[cond] = docs[:]
 
         return docs
 


### PR DESCRIPTION
Attempt to solve #423. The idea comes from lenses in general, and more specifically from Elixir's `Access` module and its kernel companion functions `get_in` and friends.

```py
query = Query().field.map(callable) == expected
query = Query()['field'].map(callable) == expected
```

---

Maybe it would be even better to avoid an extra method altogether and use `__getitem__`:

```py
query = Query().field[callable] == expected
query = Query()['field'][callable] == expected
```

WDYT?