### PR TITLE
Trigger CI on pull_request

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -2,7 +2,7 @@ name: Python CI
 
 on:
   push: {}
-  pull_request_target:
+  pull_request:
     branches: [ master ]
 
 jobs:


### PR DESCRIPTION
pull_request_target always runs against the merge base commit because it provides elevated permissions. This means CI never actually runs on any pull request! See #460. I think the change will take effect after merging this commit to master, but I am not 100% sure.