### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -9,7 +9,7 @@ Here are some extensions that might be useful to you:
 | **Repo:**        https://github.com/ASMfreaK/aiotinydb
 | **Status:**      *stable*
 | **Description:** asyncio compatibility shim for TinyDB. Enables usage of
-                   TinyDB in asyncio-aware contexts without slow syncronous
+                   TinyDB in asyncio-aware contexts without slow synchronous
                    IO.
 
 

--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -9,7 +9,7 @@ Version 4.0
 - API changes:
     - Replace ``TinyDB.purge_tables(...)`` with ``TinyDB.drop_tables(...)``
     - Replace ``TinyDB.purge_table(...)`` with ``TinyDB.drop_table(...)``
-    - Replace ``Table.purge()`` with ``Table.trunacte()``
+    - Replace ``Table.purge()`` with ``Table.truncate()``
     - Replace ``TinyDB(default_table='name')`` with ``TinyDB.default_table_name = 'name'``
     - Replace ``TinyDB(table_class=Class)`` with ``TinyDB.table_class = Class``
     - If you were using ``TinyDB.DEFAULT_TABLE``, ``TinyDB.DEFAULT_TABLE_KWARGS``,
@@ -35,7 +35,7 @@ Breaking API Changes
          notation can be used: ``where('a.b.c')`` is now
          ``Query()['a.b.c']``.
 
-  -  Checking for the existence of a key has to be done explicitely:
+  -  Checking for the existence of a key has to be done explicitly:
      ``where('foo').exists()``.
 
 -  ``SmartCacheTable`` has been moved to `msiemens/tinydb-smartcache`_.

--- a/tinydb/queries.py
+++ b/tinydb/queries.py
@@ -382,7 +382,7 @@ class Query(QueryInstance):
 
         .. warning::
 
-            The test fuction provided needs to be deterministic (returning the
+            The test function provided needs to be deterministic (returning the
             same value when provided with the same arguments), otherwise this
             may mess up the query cache that :class:`~tinydb.table.Table`
             implements.


### PR DESCRIPTION
There are small typos in:
- docs/extensions.rst
- docs/upgrade.rst
- tinydb/queries.py

Fixes:
- Should read `truncate` rather than `trunacte`.
- Should read `synchronous` rather than `syncronous`.
- Should read `function` rather than `fuction`.
- Should read `explicitly` rather than `explicitely`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md