### PR TITLE
Atomic replace (second attempt)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,8 @@ def db(request):
         db_.drop_tables()
         db_.insert_multiple({'int': 1, 'char': c} for c in 'abc')
 
-        yield db_
+        with db_:
+            yield db_
 
 
 @pytest.fixture

--- a/tinydb/storages.py
+++ b/tinydb/storages.py
@@ -126,6 +126,10 @@ class JSONStorage(Storage):
             return json.load(self._handle)
 
     def write(self, data: Dict[str, Dict[str, Any]]):
+        if self._handle.closed:
+            # imitate what would be raised by calling `write()` on a closed file
+            raise ValueError("I/O operation on a closed file.")
+
         file_name = self._handle.name
 
         # Create a temporary file in the same folder

--- a/tinydb/storages.py
+++ b/tinydb/storages.py
@@ -146,10 +146,10 @@ class JSONStorage(Storage):
 
         # Replace the current file with the temporary file
         temp_file.close()
-        os.rename(temp_file.name, file_name)
+        self._handle.close()
+        os.replace(temp_file.name, file_name)
 
         # Reopen the file
-        self._handle.close()
         self._handle = open(file_name, mode=self._mode, encoding=self._handle.encoding)
 
 


### PR DESCRIPTION
Revamp of #468. Fixes #467.

I was in a position to fix this one because during the python-atomicwrites package fiasco I read somewhere that the author basically said people should be using `os.replace` anyway.  Other platform-dependent errors were fixed basically by closing file handles in the right order.