### PR TITLE
docs: fix typos

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -62,7 +62,7 @@ v4.5.2 (2021-09-23)
 
 - Fix: Make ``Table.delete()``'s argument priorities consistent with
   other table methods. This means that if you pass both ``cond`` as
-  well as ``doc_ids`` to ``Table.delete()``, the latter will be prefered
+  well as ``doc_ids`` to ``Table.delete()``, the latter will be preferred
   (see `issue 424 <https://github.com/msiemens/tinydb/issues/424>`__)
 
 v4.5.1 (2021-07-17)
@@ -329,7 +329,7 @@ v3.4.1 (2017-08-23)
 v3.4.0 (2017-08-08)
 ^^^^^^^^^^^^^^^^^^^
 
-- Add new update operations: ``add(key, value)``, ``substract(key, value)``,
+- Add new update operations: ``add(key, value)``, ``subtract(key, value)``,
   and ``set(key, value)``
   (see `pull request #145 <https://github.com/msiemens/tinydb/pull/145>`_).
 
@@ -425,7 +425,7 @@ v3.0.0 (2015-11-13)
          notation can be used: ``where('a.b.c')`` is now
          ``Query()['a.b.c']``.
 
-   -  Checking for the existence of a key has to be done explicitely:
+   -  Checking for the existence of a key has to be done explicitly:
       ``where('foo').exists()``.
 
 -  Migrations from v1 to v2 have been removed.

--- a/tinydb/__init__.py
+++ b/tinydb/__init__.py
@@ -1,7 +1,7 @@
 """
 TinyDB is a tiny, document oriented database optimized for your happiness :)
 
-TinyDB stores differrent types of Python data types using a configurable
+TinyDB stores different types of Python data types using a configurable
 storage mechanism. It comes with a syntax for querying data and storing
 data in multiple tables.
 

--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -114,7 +114,7 @@ class TinyDB(TableBase):
 
         If the table hasn't been accessed yet, a new table instance will be
         created using the :attr:`~tinydb.database.TinyDB.table_class` class.
-        Otherwise, the previously created table instance wil be returned.
+        Otherwise, the previously created table instance will be returned.
 
         All further options besides the name are passed to the table class which
         by default is :class:`~tinydb.table.Table`. Check its documentation

--- a/tinydb/table.py
+++ b/tinydb/table.py
@@ -666,7 +666,7 @@ class Table:
         max_id = max(self.document_id_class(i) for i in table.keys())
         next_id = max_id + 1
 
-        # The next ID we wil return AFTER this call needs to be larger than
+        # The next ID we will return AFTER this call needs to be larger than
         # the current next ID we calculated
         self._next_id = next_id + 1
 


### PR DESCRIPTION
Found via `codespell -S .mypy_cache`