### PR TITLE
Do not clear your testdb in the beginning

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-import os.path
-import tempfile
 from pathlib import Path
 
 import pytest  # type: ignore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,5 +21,11 @@ def db(request, tmp_path: Path):
 
 
 @pytest.fixture
+def db_empty(db: TinyDB):
+    db.drop_tables()
+    return db
+
+
+@pytest.fixture
 def storage():
     return CachingMiddleware(MemoryStorage)()

--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -18,13 +18,11 @@ def test_drop_tables(db: TinyDB):
     assert len(db) == 0
 
 
-def test_all(db: TinyDB):
-    db.drop_tables()
+def test_all(db_empty: TinyDB):
+    for _ in range(10):
+        db_empty.insert({})
 
-    for i in range(10):
-        db.insert({})
-
-    assert len(db.all()) == 10
+    assert len(db_empty.all()) == 10
 
 
 def test_insert(db: TinyDB):


### PR DESCRIPTION
This new fixture allows to get rid of line: db.drop_tables()` in case where it in the
beginning of the tests. This pull request show a possible new fixture and its implementation in one test

Possible problems:
- lots of changes with names. db -> db_empty
- rename old fixture to something like db_filled, and my fixture could be just db

I reuse the old fuxture db in my new one, so all test will be passed
