### PR TITLE
Get Multiple Documents through get method of Table

### DIFF
--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -366,7 +366,10 @@ def test_get_ids(db: TinyDB):
     assert db.get(doc_id=el.doc_id) == el
     assert db.get(doc_id=float('NaN')) is None  # type: ignore
 
-
+def test_get_multiple_ids(db: TinyDB):
+    el = db.all()
+    assert db.get(doc_id=[x.doc_id for x in el]) == el
+    
 def test_get_invalid(db: TinyDB):
     with pytest.raises(RuntimeError):
         db.get()

--- a/tinydb/table.py
+++ b/tinydb/table.py
@@ -283,7 +283,7 @@ class Table:
     ) -> Optional[Union[Document , List[Document]]]:
         """
         Get exactly one document specified by a query or a document ID.
-        However if muliple document IDs are given then reurns all docu-
+        However if muliple document IDs are given then returns all docu-
         ments in a list.
         
         Returns ``None`` if the document doesn't exist.
@@ -292,8 +292,7 @@ class Table:
         :param doc_id: the document's ID
 
         :returns: the document(s) or ``None``
-        """
-        
+        """      
         if doc_id is not None:
             table = self._read_table()
             if isinstance(doc_id , int):


### PR DESCRIPTION
The feature augmentation in the table class is as per the requirement of #486. The user can now query multiple documents by specifying multiple doc_ids in form of a list in the get method of the Table class:

```python
from tinydb import TinyDB, Query
db = TinyDB('/path/to/db.json')
db.insert({'int': 1, 'char': 'a'})
db.insert({'int': 1, 'char': 'b'})
db.get(doc_ids = [1,2]) # will return both the documents in form of list
```