### PR TITLE
Fix changelog link 404

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ packages = [
 ]
 
 [tool.poetry.urls]
-"Changelog" = "https://github.com/msiemens/tinydb/en/latest/changelog.html"
+"Changelog" = "https://tinydb.readthedocs.io/en/latest/changelog.html"
 "Issues" = "https://github.com/msiemens/tinydb/issues"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Currently the changelog link on pypi results in 404.
PyPI page: https://pypi.org/project/tinydb/

Since people looking at the changelog from PyPI probably want released changes, the change is to point to the RTD changelog.
Another option is to point to the docs/changelog.rst, of course.