### PR TITLE
feat: persist empty tables

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -169,3 +169,11 @@ def test_table_repr(db):
 def test_truncate_table(db):
     db.truncate()
     assert db._get_next_id() == 1
+
+
+def test_persist_table(db):
+    db.table("persisted", persist_empty=True)
+    assert "persisted" in db.tables()
+
+    db.table("nonpersisted", persist_empty=False)
+    assert "nonpersisted" not in db.tables()

--- a/tinydb/table.py
+++ b/tinydb/table.py
@@ -98,7 +98,8 @@ class Table:
         self,
         storage: Storage,
         name: str,
-        cache_size: int = default_query_cache_capacity
+        cache_size: int = default_query_cache_capacity,
+        persist_empty: bool = False
     ):
         """
         Create a table instance.
@@ -110,6 +111,8 @@ class Table:
             = self.query_cache_class(capacity=cache_size)
 
         self._next_id = None
+        if persist_empty:
+            self._update_table(lambda table: table.clear())
 
     def __repr__(self):
         args = [
@@ -163,7 +166,7 @@ class Table:
             if doc_id in table:
                 raise ValueError(f'Document with ID {str(doc_id)} '
                                  f'already exists')
-                
+
             # By calling ``dict(document)`` we convert the data we got to a
             # ``dict`` instance even if it was a different class that
             # implemented the ``Mapping`` interface
@@ -676,7 +679,7 @@ class Table:
         """
         Read the table data from the underlying storage.
 
-        Documents and doc_ids are NOT yet transformed, as 
+        Documents and doc_ids are NOT yet transformed, as
         we may not want to convert *all* documents when returning
         only one document for example.
         """

--- a/tinydb/table.py
+++ b/tinydb/table.py
@@ -72,6 +72,7 @@ class Table:
     :param storage: The storage instance to use for this table
     :param name: The table name
     :param cache_size: Maximum capacity of query cache
+    :param persist_empty: Store new table even with no operations on it
     """
 
     #: The class used to represent documents


### PR DESCRIPTION
Allows persisting empty tables when parameter `persist_empty` is set, similar to SQL CREATE TABLE statement.

Related issue: https://github.com/msiemens/tinydb/issues/513
