### PR TITLE
Fix Broken link in documentation (PyMongo docs link)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ TinyDB is:
   fun to use by providing a simple and clean API.
 
 - **written in pure Python:** TinyDB neither needs an external server (as
-  e.g. `PyMongo <https://api.mongodb.org/python/current/>`_) nor any dependencies
+  e.g. `PyMongo <https://pymongo.readthedocs.io/en/stable/>`_) nor any dependencies
   from PyPI.
 
 - **works on Python 3.8+ and PyPy3:** TinyDB works on all modern versions of Python


### PR DESCRIPTION
This error was found/reported by user [@carl0smat3us](https://github.com/carl0smat3us) in issue #539.