### PR TITLE
Add mention to no-op query in docs, tweak sentence

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -201,6 +201,8 @@ queries:
     <https://docs.python.org/3/reference/expressions.html#operator-precedence>`_
     for details.
 
+    You can compose queries dynamically by using the no-op query ``Query().noop()``.
+
 Recap
 .....
 
@@ -322,7 +324,7 @@ In order to perform multiple update operations at once, you can use the
 ...     ({'int': 4}, where('char') == 'b'),
 ... ])
 
-You also can use mix normal updates with update operations:
+You also can mix normal updates with update operations:
 
 >>> db.update_multiple([
 ...     ({'int': 2}, where('char') == 'a'),


### PR DESCRIPTION
I wanted to build some dynamic queries and it took some time until I spotted the `noop` method. :sweat_smile: An explicit mention in the docs might help others in the same situation. Besides, a sentence seems to have two verbs.

Thanks and congrats for the project!