### PR TITLE
Demonstrate the use of `~` as the NOT operator in the README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,10 @@ Query Language
     >>> db.search((User.name == 'John') | (User.name == 'Bob'))
     [{'name': 'John', 'age': 22}, {'name': 'John', 'age': 37}, {'name': 'Bob', 'age': 42}]
 
+    >>> # Negate a query with logical not
+    >>> db.search(~(User.name == 'John'))
+    [{'name': 'Megan', 'age': 27}, {'name': 'Bob', 'age': 42}]
+
     >>> # Apply transformation to field with `map`
     >>> db.search((User.age.map(lambda x: x + x) == 44))
     >>> [{'name': 'John', 'age': 22}]


### PR DESCRIPTION
I had a use case which needed !exists(), and tried `NOT`/`!`/`not` but not `~`. Finding that was the name from the docs was not obvious and I'm still not sure where it hides.

I proceeded to then implement a whole duplicate of `_generate_test()` that had reversed polarity (and this was quite easy and fast, props on being easy to modify), which is probably not the normal result of missing this feature, but it does seem like it's easy to miss. Fortunately, before making a PR for that I considered the other alternative.

At least two other people (asker and answerer) have had this confusion: https://groups.google.com/g/mitappinventortest/c/QKkZL2oWCw8