### PR TITLE
Refactor __repr__ method in TinyDB class for clarity and consistency

### DIFF
--- a/tinydb/database.py
+++ b/tinydb/database.py
@@ -1,6 +1,7 @@
 """
 This module contains the main component of TinyDB: the database.
 """
+
 from typing import Dict, Iterator, Set, Type
 
 from . import JSONStorage
@@ -76,7 +77,7 @@ class TinyDB(TableBase):
     #: The name of the default table
     #:
     #: .. versionadded:: 4.0
-    default_table_name = '_default'
+    default_table_name = "_default"
 
     #: The class that will be used by default to create storage instances
     #:
@@ -88,7 +89,7 @@ class TinyDB(TableBase):
         Create a new instance of TinyDB.
         """
 
-        storage = kwargs.pop('storage', self.default_storage_class)
+        storage = kwargs.pop("storage", self.default_storage_class)
 
         # Prepare the storage
         self._storage: Storage = storage(*args, **kwargs)
@@ -97,16 +98,15 @@ class TinyDB(TableBase):
         self._tables: Dict[str, Table] = {}
 
     def __repr__(self):
+
         args = [
-            'tables={}'.format(list(self.tables())),
-            'tables_count={}'.format(len(self.tables())),
-            'default_table_documents_count={}'.format(self.__len__()),
-            'all_tables_documents_count={}'.format(
-                ['{}={}'.format(table, len(self.table(table)))
-                 for table in self.tables()]),
+            f"tables={list(self.tables())}",
+            f"tables_count={len(self.tables())}",
+            f"default_table_documents_count={self.__len__()}",
+            f'all_tables_documents_count={[f"{table}={len(self.table(table))}" for table in self.tables()]}',
         ]
 
-        return '<{} {}>'.format(type(self).__name__, ', '.join(args))
+        return "<{} {}>".format(type(self).__name__, ", ".join(args))
 
     def table(self, name: str, **kwargs) -> Table:
         """


### PR DESCRIPTION
This pull request improves the `__repr__` method in the `TinyDB` class for better readability and maintainability by:
- Using f-strings instead of `.format()` for string interpolation.
- Keeping the functionality identical while improving clarity and modernizing the code style.
- Verified with tests to ensure no changes to functionality.
