### PR TITLE
Freeze Refactor - Diminish Cyclomatic Complexity

### DIFF
--- a/tinydb/utils.py
+++ b/tinydb/utils.py
@@ -145,15 +145,11 @@ def freeze(obj):
     """
     Freeze an object by making it immutable and thus hashable.
     """
-    if isinstance(obj, dict):
-        # Transform dicts into ``FrozenDict``s
-        return FrozenDict((k, freeze(v)) for k, v in obj.items())
-    elif isinstance(obj, list):
-        # Transform lists into tuples
-        return tuple(freeze(el) for el in obj)
-    elif isinstance(obj, set):
-        # Transform sets into ``frozenset``s
-        return frozenset(obj)
-    else:
-        # Don't handle all other objects
-        return obj
+    type_to_function = {
+        dict: lambda d: FrozenDict((k, freeze(v)) for k, v in d.items()),
+        list: lambda l: tuple(freeze(el) for el in l),
+        set: lambda s: frozenset(s),
+    }
+    
+    transform = type_to_function.get(type(obj), lambda x: x)
+    return transform(obj)


### PR DESCRIPTION
Hello!
I would like to contribute to TinyDB by reducing the cyclomatic complexity of one of its methods.

I used the Codalyze Tool to statically analyze the code, and after extracting the result from all the software, it turns out that the freeze method has the highest cyclomatic complexity in TinyDB.
After the refactoring, it was possible to obtain a score of 6, for 3 points, on a scale of 0 to 10.

I hope you'll consider this change, and I'm excited to contribute to TinyDB.

Codalyze Tool: https://github.com/selcukusta/codalyze-rest-api