### PR TITLE
docs(contributing): fix broken `GitHub Flow` url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,7 @@ extensions: Contributions to TinyDB are welcome! Here's how to get started:
    a feature idea or a bug
 2. Fork `the repository <https://github.com/msiemens/tinydb/>`_ on Github,
    create a new branch off the `master` branch and start making your changes
-   (known as `GitHub Flow <https://guides.github.com/introduction/flow/index.html>`_)
+   (known as `GitHub Flow <https://docs.github.com/en/get-started/using-github/github-flow>`_)
 3. Write a test which shows that the bug was fixed or that the feature works
    as expected
 4. Send a pull request and bug the maintainer until it gets merged and


### PR DESCRIPTION
`guides.github.com` doesn't exist anymore. I updated the URL for GitHub Flow to point to the reference in the docs instead.