### PR TITLE
Provide more precise type hints for Table.get

### DIFF
--- a/tinydb/table.py
+++ b/tinydb/table.py
@@ -10,6 +10,7 @@ from typing import (
     Iterator,
     List,
     Mapping,
+    NoReturn,
     Optional,
     Union,
     cast,
@@ -280,6 +281,9 @@ class Table:
             self._query_cache[cond] = docs[:]
 
         return docs
+
+    @overload
+    def get(self) -> NoReturn: ...
 
     @overload
     def get(

--- a/tinydb/table.py
+++ b/tinydb/table.py
@@ -304,17 +304,17 @@ class Table:
     @overload
     def get(
         self, cond: Optional[QueryLike], doc_id: None, doc_ids: List
-    ) -> Optional[List[Document]]: ...
+    ) -> List[Document]: ...
 
     @overload
     def get(
         self, cond: Optional[QueryLike], *, doc_id: None = ..., doc_ids: List
-    ) -> Optional[List[Document]]: ...
+    ) -> List[Document]: ...
 
     @overload
     def get(
         self, *, cond: Optional[QueryLike] = ..., doc_id: None = ..., doc_ids: List
-    ) -> Optional[List[Document]]: ...
+    ) -> List[Document]: ...
 
     def get(
         self,

--- a/tinydb/table.py
+++ b/tinydb/table.py
@@ -13,7 +13,8 @@ from typing import (
     Optional,
     Union,
     cast,
-    Tuple
+    Tuple,
+    overload
 )
 
 from .queries import QueryLike
@@ -280,12 +281,47 @@ class Table:
 
         return docs
 
+    @overload
+    def get(
+        self, cond: QueryLike, doc_id: None = ..., doc_ids: None = ...
+    ) -> Optional[Document]: ...
+
+    @overload
+    def get(
+        self, *, cond: QueryLike, doc_id: None = ..., doc_ids: None = ...
+    ) -> Optional[Document]: ...
+
+    @overload
+    def get(
+        self, cond: Optional[QueryLike], doc_id: int, doc_ids: Optional[List] = ...
+    ) -> Optional[Document]: ...
+
+    @overload
+    def get(
+        self, *, cond: Optional[QueryLike] = ..., doc_id: int, doc_ids: Optional[List] = ...,
+    ) -> Optional[Document]: ...
+
+    @overload
+    def get(
+        self, cond: Optional[QueryLike], doc_id: None, doc_ids: List
+    ) -> Optional[List[Document]]: ...
+
+    @overload
+    def get(
+        self, cond: Optional[QueryLike], *, doc_id: None = ..., doc_ids: List
+    ) -> Optional[List[Document]]: ...
+
+    @overload
+    def get(
+        self, *, cond: Optional[QueryLike] = ..., doc_id: None = ..., doc_ids: List
+    ) -> Optional[List[Document]]: ...
+
     def get(
         self,
         cond: Optional[QueryLike] = None,
         doc_id: Optional[int] = None,
         doc_ids: Optional[List] = None
-    ) -> Optional[Union[Document, List[Document]]]:
+    ):
         """
         Get exactly one document specified by a query or a document ID.
         However, if multiple document IDs are given then returns all


### PR DESCRIPTION
When working with pyright (at least), the return value from calls to Table.get is the declared type `Document | list[Document] | None`. To avoid type errors when using the return value, one therefore has do one of the following:

- Exclude the line from type checking
- Introduce an assertion, e.g. `assert isinstance(obj, Document)`
- Test, say, `if instance(obj, Document)` instead of `if obj is not None` or `if obj`

It would be highly convenient if static type checkers could understand the logic of the method, and knew that it returns a list if and only if `doc_id` is None and a list is passed to `doc_ids`.

Here are the typing overloads that do the trick. I've confirmed that pytest and mypy remain happy with these in place. I haven't covered the case that passing no arguments leads to a `NoReturn` return type, as that's adding more information than was already there, but I could if you wanted.

I could provide some `assert_type` tests if you like but I'm not so familiar with the best place to put them (and they would involve a `typing_extensions` dependency on older Pythons).