### PR TITLE
feat(tinydb): add b-tree index support for document lookup

### DIFF
--- a/tinydb/index.py
+++ b/tinydb/index.py
@@ -1,0 +1,381 @@
+"""
+Contains the :class:`BTreeIndex` for optimized field lookups.
+
+TinyDB's default behavior is to perform a linear scan (O(n)) for every
+search operation. This module provides a B-Tree implementation that
+improves search complexity to O(log n) without adding any external
+dependencies.
+
+Key features:
+    - Supports duplicate keys by storing a list of document IDs for each key.
+    - In-memory index that stays synchronized with TinyDB's storage.
+    - Supports any comparable Python type (str, int, float, etc.).
+"""
+
+from typing import Any, List, Optional, Tuple
+
+
+class BTreeNode:
+    """
+    A node in the B-Tree.
+
+    Each node stores a sorted list of keys and, if it is not a leaf, pointers
+    to its children. The separation between leaf and internal nodes allows
+    the tree to self-balance during insertions and deletions.
+    """
+
+    def __init__(self, leaf: bool = False):
+        self.keys: List[Any] = []              # Sorted keys (indexed field values)
+        self.doc_ids: List[List[int]] = []     # List of document IDs for each key
+        self.children: List['BTreeNode'] = []  # Child nodes (empty if leaf)
+        self.leaf: bool = leaf                 # Whether this is a leaf node
+
+
+class BTreeIndex:
+    """
+    A B-Tree index for TinyDB.
+
+    The ``order`` parameter controls the node capacity. Higher values result
+    in wider nodes and fewer tree levels.
+    """
+
+    def __init__(self, order: int = 50):
+        self.root: BTreeNode = BTreeNode(leaf=True)
+        self.order: int = order
+
+    # ------------------------------------------------------------------
+    # Public API - these are the methods used by table.py
+    # ------------------------------------------------------------------
+
+    def insert(self, key: Any, doc_id: int) -> None:
+        """
+        Insert a document ID into the index under the given key.
+
+        If the key already exists (another document has the same field value),
+        the ``doc_id`` is appended to the existing list.
+
+        :param key: The field value to index
+        :param doc_id: The document ID to associate with the key
+        """
+        root = self.root
+
+        # Check if the key already exists to avoid duplicate keys in the tree
+        existing_node, existing_idx = self._find_key_node(root, key)
+        if existing_node is not None:
+            existing_node.doc_ids[existing_idx].append(doc_id)
+            return
+
+        # If the root is full, the tree grows upward
+        if len(root.keys) == (2 * self.order) - 1:
+            new_root = BTreeNode(leaf=False)
+            new_root.children.append(self.root)
+            self._split_child(new_root, 0)
+            self.root = new_root
+
+        self._insert_non_full(self.root, key, doc_id)
+
+    def search(self, key: Any) -> List[int]:
+        """
+        Return all document IDs that match the given key value.
+
+        :param key: The field value to search for
+        :returns: List of matching document IDs, or empty list if none found
+        """
+        return self._search_node(self.root, key)
+
+    def delete(self, key: Any, doc_id: int) -> None:
+        """
+        Remove a specific document ID from the index for the given key.
+
+        The key is only removed from the tree if no more document IDs are
+        associated with it.
+
+        :param key: The field value to remove from
+        :param doc_id: The document ID to remove
+        """
+        node, idx = self._find_key_node(self.root, key)
+
+        if node is None:
+            return  # Key doesn't exist
+
+        if doc_id in node.doc_ids[idx]:
+            node.doc_ids[idx].remove(doc_id)
+
+        # If no more documents for this key, remove it from the tree
+        if not node.doc_ids[idx]:
+            self._delete_key(self.root, key)
+
+    def update(self, old_key: Any, new_key: Any, doc_id: int) -> None:
+        """
+        Update the index when a document's field value changes.
+
+        Removes the old entry and creates a new one.
+
+        :param old_key: The previous field value
+        :param new_key: The new field value
+        :param doc_id: The document ID being updated
+        """
+        self.delete(old_key, doc_id)
+        self.insert(new_key, doc_id)
+
+    def clear(self) -> None:
+        """
+        Clear the index completely. Called when the table is truncated.
+        """
+        self.root = BTreeNode(leaf=True)
+
+    # ------------------------------------------------------------------
+    # Internal B-Tree methods
+    # ------------------------------------------------------------------
+
+    def _find_key_node(
+        self, node: BTreeNode, key: Any
+    ) -> Tuple[Optional[BTreeNode], int]:
+        """
+        Find which node in the tree stores a given key.
+
+        Traverses the node's keys from left to right to find the correct
+        position, descending to the appropriate child if necessary.
+        Returns the node and key index, or (None, -1) if not found.
+        """
+        i = 0
+        while i < len(node.keys) and key > node.keys[i]:
+            i += 1
+
+        if i < len(node.keys) and key == node.keys[i]:
+            return node, i
+
+        if node.leaf:
+            return None, -1
+
+        return self._find_key_node(node.children[i], key)
+
+    def _search_node(self, node: BTreeNode, key: Any) -> List[int]:
+        """
+        Traverse the tree looking for a key and return its document IDs.
+
+        Similar logic to _find_key_node, but returns the data directly.
+        """
+        i = 0
+        while i < len(node.keys) and key > node.keys[i]:
+            i += 1
+
+        if i < len(node.keys) and key == node.keys[i]:
+            return list(node.doc_ids[i])  # Return a copy to avoid exposing internal state
+
+        if node.leaf:
+            return []
+
+        return self._search_node(node.children[i], key)
+
+    def _insert_non_full(self, node: BTreeNode, key: Any, doc_id: int) -> None:
+        """
+        Insert a key into a node that has available space.
+
+        In leaf nodes, finds the correct position and inserts directly.
+        In internal nodes, descends to the appropriate child, splitting
+        it first if necessary.
+        """
+        i = len(node.keys) - 1
+
+        if node.leaf:
+            # Make room at the end and shift larger keys to the right
+            node.keys.append(key)  # Placeholder, will be shifted
+            node.doc_ids.append([])  # Placeholder, type-safe
+
+            while i >= 0 and key < node.keys[i]:
+                node.keys[i + 1] = node.keys[i]
+                node.doc_ids[i + 1] = node.doc_ids[i]
+                i -= 1
+
+            node.keys[i + 1] = key
+            node.doc_ids[i + 1] = [doc_id]
+        else:
+            # Find the correct child by traversing right to left
+            while i >= 0 and key < node.keys[i]:
+                i -= 1
+            i += 1
+
+            # If the child is full, split it before descending
+            if len(node.children[i].keys) == (2 * self.order) - 1:
+                self._split_child(node, i)
+                # After the split there are two children where there was one
+                if key > node.keys[i]:
+                    i += 1
+
+            self._insert_non_full(node.children[i], key, doc_id)
+
+    def _split_child(self, parent: BTreeNode, i: int) -> None:
+        """
+        Split a full child node, promoting the middle key to the parent.
+
+        This is how the B-Tree grows: when a node becomes full, it splits
+        in two and pushes a key upward, keeping the tree balanced.
+        """
+        order = self.order
+        child = parent.children[i]
+        new_node = BTreeNode(leaf=child.leaf)
+        mid = order - 1
+
+        # The middle key moves up to the parent
+        parent.keys.insert(i, child.keys[mid])
+        parent.doc_ids.insert(i, child.doc_ids[mid])
+        parent.children.insert(i + 1, new_node)
+
+        # The right half goes to the new node
+        new_node.keys = child.keys[mid + 1:]
+        new_node.doc_ids = child.doc_ids[mid + 1:]
+
+        # The left half stays in the original node
+        child.keys = child.keys[:mid]
+        child.doc_ids = child.doc_ids[:mid]
+
+        if not child.leaf:
+            new_node.children = child.children[mid + 1:]
+            child.children = child.children[:mid + 1]
+
+    def _delete_key(self, node: BTreeNode, key: Any) -> None:
+        """
+        Remove a key from the tree, handling three possible scenarios:
+        the key is in a leaf, in an internal node, or not in the current
+        node (requiring descent to the correct child).
+
+        Before descending, ensures the child has enough keys to handle
+        a removal without violating B-Tree properties.
+        """
+        order = self.order
+        i = 0
+
+        while i < len(node.keys) and key > node.keys[i]:
+            i += 1
+
+        if i < len(node.keys) and node.keys[i] == key:
+            if node.leaf:
+                # Simplest case: key is in a leaf, remove directly
+                node.keys.pop(i)
+                node.doc_ids.pop(i)
+            else:
+                # Key is in an internal node: replace with predecessor
+                # (the largest key from the left subtree) to maintain order
+                pred_node, pred_idx = self._get_predecessor(node.children[i])
+                node.keys[i] = pred_node.keys[pred_idx]
+                node.doc_ids[i] = pred_node.doc_ids[pred_idx]
+                self._delete_key(node.children[i], pred_node.keys[pred_idx])
+        else:
+            if node.leaf:
+                return  # Key does not exist in the tree
+
+            # Ensure the child has enough keys before descending
+            if len(node.children[i].keys) < order:
+                self._fill_child(node, i)
+                if i > len(node.keys):
+                    i -= 1
+
+            self._delete_key(node.children[i], key)
+
+    def _get_predecessor(self, node: BTreeNode) -> Tuple[BTreeNode, int]:
+        """
+        Find the largest key in the subtree by descending rightward.
+        Used to replace a key removed from an internal node.
+        """
+        while not node.leaf:
+            node = node.children[-1]
+        return node, len(node.keys) - 1
+
+    def _fill_child(self, parent: BTreeNode, i: int) -> None:
+        """
+        Ensure child i has enough keys before a removal.
+
+        First tries to borrow from an adjacent sibling; if neither has
+        spare keys, merges with a sibling.
+        """
+        order = self.order
+
+        if i > 0 and len(parent.children[i - 1].keys) >= order:
+            self._borrow_from_left(parent, i)
+        elif i < len(parent.children) - 1 and len(parent.children[i + 1].keys) >= order:
+            self._borrow_from_right(parent, i)
+        else:
+            if i < len(parent.children) - 1:
+                self._merge_children(parent, i)
+            else:
+                self._merge_children(parent, i - 1)
+
+    def _borrow_from_left(self, parent: BTreeNode, i: int) -> None:
+        """
+        Transfer the largest key from the left sibling to child i,
+        passing through the parent to maintain correct ordering.
+        """
+        child = parent.children[i]
+        sibling = parent.children[i - 1]
+
+        child.keys.insert(0, parent.keys[i - 1])
+        child.doc_ids.insert(0, parent.doc_ids[i - 1])
+
+        if not child.leaf:
+            child.children.insert(0, sibling.children.pop())
+
+        parent.keys[i - 1] = sibling.keys.pop()
+        parent.doc_ids[i - 1] = sibling.doc_ids.pop()
+
+    def _borrow_from_right(self, parent: BTreeNode, i: int) -> None:
+        """
+        Transfer the smallest key from the right sibling to child i,
+        passing through the parent to maintain correct ordering.
+        """
+        child = parent.children[i]
+        sibling = parent.children[i + 1]
+
+        child.keys.append(parent.keys[i])
+        child.doc_ids.append(parent.doc_ids[i])
+
+        if not child.leaf:
+            child.children.append(sibling.children.pop(0))
+
+        parent.keys[i] = sibling.keys.pop(0)
+        parent.doc_ids[i] = sibling.doc_ids.pop(0)
+
+    def _merge_children(self, parent: BTreeNode, i: int) -> None:
+        """
+        Merge child i with child i+1 into a single node, absorbing the
+        parent key that separated them. If the parent is the root and
+        becomes empty after the merge, the merged child becomes the new root.
+        """
+        child = parent.children[i]
+        sibling = parent.children[i + 1]
+
+        # The parent key that separated the two children descends to merged node
+        child.keys.append(parent.keys[i])
+        child.doc_ids.append(parent.doc_ids[i])
+
+        child.keys.extend(sibling.keys)
+        child.doc_ids.extend(sibling.doc_ids)
+        if not child.leaf:
+            child.children.extend(sibling.children)
+
+        parent.keys.pop(i)
+        parent.doc_ids.pop(i)
+        parent.children.pop(i + 1)
+
+        # Empty root means the tree shrunk one level
+        if parent is self.root and len(parent.keys) == 0:
+            self.root = child
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        """Return the total number of unique keys in the index."""
+        return self._count_keys(self.root)
+
+    def _count_keys(self, node: BTreeNode) -> int:
+        """Count keys recursively by traversing all nodes."""
+
+        count = len(node.keys)
+        for child in node.children:
+            count += self._count_keys(child)
+        return count
+
+    def __repr__(self) -> str:
+        return f"BTreeIndex(keys={len(self)})"

--- a/tinydb/table.py
+++ b/tinydb/table.py
@@ -21,6 +21,7 @@ from typing import (
 from .queries import QueryLike
 from .storages import Storage
 from .utils import LRUCache
+from .index import BTreeIndex
 
 __all__ = ('Document', 'Table')
 
@@ -114,6 +115,7 @@ class Table:
             = self.query_cache_class(capacity=cache_size)
 
         self._next_id = None
+        self._indices: Dict[str, BTreeIndex] = {}
         if persist_empty:
             self._update_table(lambda table: table.clear())
 
@@ -139,6 +141,26 @@ class Table:
         Get the table storage instance.
         """
         return self._storage
+
+    def create_index(self, field: str, order: int = 50) -> None:
+        """
+        Create a B-Tree index for the given field.
+
+        This builds the index by scanning all existing documents and then
+        keeps it synchronized on every insert, update, and remove operation.
+        Only simple top-level fields are supported.
+
+        :param field: the document field to index
+        :param order: the B-Tree order (higher = wider nodes, fewer levels)
+        """
+        index = BTreeIndex(order=order)
+
+        # Populate the index with existing documents
+        for doc_id, doc in self._read_table().items():
+            if field in doc:
+                index.insert(doc[field], self.document_id_class(doc_id))
+
+        self._indices[field] = index
 
     def insert(self, document: Mapping) -> int:
         """
@@ -177,6 +199,12 @@ class Table:
 
         # See below for details on ``Table._update``
         self._update_table(updater)
+
+        # Update all indices with the new document
+        doc_dict = dict(document)
+        for field, index in self._indices.items():
+            if field in doc_dict:
+                index.insert(doc_dict[field], doc_id)
 
         return doc_id
 
@@ -222,6 +250,16 @@ class Table:
         # See below for details on ``Table._update``
         self._update_table(updater)
 
+        # Update all indices with the newly inserted documents
+        if self._indices:
+            table_data = self._read_table()
+            for did in doc_ids:
+                raw = table_data.get(str(did))
+                if raw is not None:
+                    for field, index in self._indices.items():
+                        if field in raw:
+                            index.insert(raw[field], did)
+
         return doc_ids
 
     def all(self) -> List[Document]:
@@ -238,6 +276,54 @@ class Table:
 
         return list(iter(self))
 
+    def _try_index_search(
+        self, cond: QueryLike
+    ) -> Optional[List[Document]]:
+        """
+        Attempt to resolve a query using a B-Tree index.
+
+        Returns a list of matching documents if the query is a simple
+        equality check (``Query().field == value``) on an indexed field.
+        Returns ``None`` if the index cannot be used for this query,
+        signalling that the caller should fall back to a full scan.
+
+        .. note:: This optimization relies on the ``_hash`` property of the
+                  query object to identify equality comparisons. Custom query
+                  objects that do not provide a compatible ``_hash`` tuple
+                  will not benefit from index-based lookups.
+        """
+        # The hash of an equality query looks like:
+        #   ('==', (field_name,), frozen_value)
+        hashval = getattr(cond, '_hash', None)
+        if not (isinstance(hashval, tuple)
+                and len(hashval) == 3
+                and hashval[0] == '=='):
+            return None
+
+        path = hashval[1]
+        # Only single-level field paths are indexable
+        if not (isinstance(path, tuple) and len(path) == 1
+                and isinstance(path[0], str)):
+            return None
+
+        field = path[0]
+        if field not in self._indices:
+            return None
+
+        value = hashval[2]
+        doc_ids = self._indices[field].search(value)
+
+        if not doc_ids:
+            return []
+
+        # Fetch the matching documents from storage
+        table = self._read_table()
+        return [
+            self.document_class(table[str(did)], self.document_id_class(did))
+            for did in doc_ids
+            if str(did) in table
+        ]
+
     def search(self, cond: QueryLike) -> List[Document]:
         """
         Search for all documents matching a 'where' cond.
@@ -252,14 +338,19 @@ class Table:
         if cached_results is not None:
             return cached_results[:]
 
-        # Perform the search by applying the query to all documents.
-        # Then, only if the document matches the query, convert it
-        # to the document class and document ID class.
-        docs = [
-            self.document_class(doc, self.document_id_class(doc_id))
-            for doc_id, doc in self._read_table().items()
-            if cond(doc)
-        ]
+        # Try to use a B-Tree index for O(log n) lookup
+        indexed_result = self._try_index_search(cond)
+        if indexed_result is not None:
+            docs = indexed_result
+        else:
+            # Fallback: full scan — apply the query to all documents.
+            # Then, only if the document matches the query, convert it
+            # to the document class and document ID class.
+            docs = [
+                self.document_class(doc, self.document_id_class(doc_id))
+                for doc_id, doc in self._read_table().items()
+                if cond(doc)
+            ]
 
         # Only cache cacheable queries.
         #
@@ -426,13 +517,49 @@ class Table:
         # Define the function that will perform the update
         if callable(fields):
             def perform_update(table, doc_id):
+                # Capture old values for indexed fields before the update
+                if self._indices:
+                    old_vals = {
+                        f: table[doc_id].get(f)
+                        for f in self._indices if f in table[doc_id]
+                    }
                 # Update documents by calling the update function provided by
                 # the user
                 fields(table[doc_id])
+                # Sync indices with new values
+                if self._indices:
+                    for f, idx in self._indices.items():
+                        new_val = table[doc_id].get(f)
+                        old_val = old_vals.get(f)
+                        if old_val is not None and new_val is not None:
+                            if old_val != new_val:
+                                idx.update(old_val, new_val, doc_id)
+                        elif old_val is not None:
+                            idx.delete(old_val, doc_id)
+                        elif new_val is not None:
+                            idx.insert(new_val, doc_id)
         else:
             def perform_update(table, doc_id):
+                # Capture old values for indexed fields before the update
+                if self._indices:
+                    old_vals = {
+                        f: table[doc_id].get(f)
+                        for f in self._indices if f in table[doc_id]
+                    }
                 # Update documents by setting all fields from the provided data
                 table[doc_id].update(fields)
+                # Sync indices with new values
+                if self._indices:
+                    for f, idx in self._indices.items():
+                        new_val = table[doc_id].get(f)
+                        old_val = old_vals.get(f)
+                        if old_val is not None and new_val is not None:
+                            if old_val != new_val:
+                                idx.update(old_val, new_val, doc_id)
+                        elif old_val is not None:
+                            idx.delete(old_val, doc_id)
+                        elif new_val is not None:
+                            idx.insert(new_val, doc_id)
 
         if doc_ids is not None:
             # Perform the update operation for documents specified by a list
@@ -512,6 +639,13 @@ class Table:
 
         # Define the function that will perform the update
         def perform_update(fields, table, doc_id):
+            # Capture old values for indexed fields before the update
+            if self._indices:
+                old_vals = {
+                    f: table[doc_id].get(f)
+                    for f in self._indices if f in table[doc_id]
+                }
+
             if callable(fields):
                 # Update documents by calling the update function provided
                 # by the user
@@ -520,6 +654,19 @@ class Table:
                 # Update documents by setting all fields from the provided
                 # data
                 table[doc_id].update(fields)
+
+            # Sync indices with new values
+            if self._indices:
+                for f, idx in self._indices.items():
+                    new_val = table[doc_id].get(f)
+                    old_val = old_vals.get(f)
+                    if old_val is not None and new_val is not None:
+                        if old_val != new_val:
+                            idx.update(old_val, new_val, doc_id)
+                    elif old_val is not None:
+                        idx.delete(old_val, doc_id)
+                    elif new_val is not None:
+                        idx.insert(new_val, doc_id)
 
         # Perform the update operation for documents specified by a query
 
@@ -613,6 +760,15 @@ class Table:
             # to return the list of affected document IDs
             removed_ids = list(doc_ids)
 
+            # Capture indexed values before removal
+            removed_docs: Dict[int, Mapping] = {}
+            if self._indices:
+                table_snapshot = self._read_table()
+                for did in removed_ids:
+                    raw = table_snapshot.get(str(did))
+                    if raw is not None:
+                        removed_docs[did] = raw
+
             def updater(table: dict):
                 for doc_id in removed_ids:
                     table.pop(doc_id)
@@ -620,10 +776,19 @@ class Table:
             # Perform the remove operation
             self._update_table(updater)
 
+            # Update indices
+            for did, raw in removed_docs.items():
+                for field, index in self._indices.items():
+                    if field in raw:
+                        index.delete(raw[field], did)
+
             return removed_ids
 
         if cond is not None:
             removed_ids = []
+
+            # Capture indexed values before removal
+            removed_docs_: Dict[int, Mapping] = {}
 
             # This updater function will be called with the table data
             # as its first argument. See ``Table._update`` for details on this
@@ -644,11 +809,21 @@ class Table:
                         # Add document ID to list of removed document IDs
                         removed_ids.append(doc_id)
 
+                        # Capture document for index cleanup
+                        if self._indices:
+                            removed_docs_[doc_id] = dict(table[doc_id])
+
                         # Remove document from the table
                         table.pop(doc_id)
 
             # Perform the remove operation
             self._update_table(updater)
+
+            # Update indices
+            for did, raw in removed_docs_.items():
+                for field, index in self._indices.items():
+                    if field in raw:
+                        index.delete(raw[field], did)
 
             return removed_ids
 
@@ -664,6 +839,10 @@ class Table:
 
         # Reset document ID counter
         self._next_id = None
+
+        # Clear all indices
+        for index in self._indices.values():
+            index.clear()
 
     def count(self, cond: QueryLike) -> int:
         """


### PR DESCRIPTION
## What was done

This PR introduces an optional in-memory B-Tree index to improve document lookup performance in TinyDB.

By default, TinyDB performs searches using a full linear scan over in-memory documents, resulting in O(n) lookup complexity.  
With this change, indexed fields use a B-Tree structure, reducing key lookup complexity to O(log n).

The index is created on demand using `create_index(field_name)` and does not modify TinyDB’s default behavior unless explicitly enabled.

## Implementation details

- Added a new module `index.py` implementing a B-Tree index.
- Modified `Table.__init__()` to maintain an internal index registry.
- Updated:
  - `search()` to use the index when available.
  - `insert()` to update indexes on insertion.
  - `update()` to maintain index consistency.
  - `remove()` to remove entries from indexes.
- No external dependencies were introduced.

## Complexity impact

- Default search: O(n)
- Indexed search: O(log n) for key lookup + O(k) to retrieve matching documents

Where:
- n is the number of indexed documents
- k is the number of matching results

## Performance observations

Empirical tests show significant improvement in search performance for large datasets, while insert operations become slightly slower due to index maintenance (expected trade-off).

All existing tests pass:

204 passed, 1 skipped

## How to test

pip install -e .
pytest