### PR TITLE
perf: add Bloom Filter for fast negative lookups

### DIFF
--- a/tests/test_bloom_filter.py
+++ b/tests/test_bloom_filter.py
@@ -1,0 +1,262 @@
+"""
+Unit tests for the Bloom Filter implementation.
+
+This module tests the standalone BloomFilter class in isolation,
+covering initialization, add/test operations, false positive rates,
+hash determinism, rebuild, and serialization.
+"""
+
+import pytest
+
+from tinydb.bloom_filter import BloomFilter
+
+
+# ---------------------------------------------------------------------------
+# Initialization and parameter validation
+# ---------------------------------------------------------------------------
+
+class TestBloomFilterInit:
+    def test_default_parameters(self):
+        bf = BloomFilter()
+        assert bf.count == 0
+        assert bf.size > 0
+        assert bf.num_hashes > 0
+
+    def test_custom_parameters(self):
+        bf = BloomFilter(expected_items=500, false_positive_rate=0.05)
+        assert bf.count == 0
+        assert bf.size > 0
+        assert bf.num_hashes >= 1
+
+    def test_invalid_expected_items_zero(self):
+        with pytest.raises(ValueError, match='expected_items must be positive'):
+            BloomFilter(expected_items=0)
+
+    def test_invalid_expected_items_negative(self):
+        with pytest.raises(ValueError, match='expected_items must be positive'):
+            BloomFilter(expected_items=-10)
+
+    def test_invalid_fp_rate_zero(self):
+        with pytest.raises(ValueError, match='false_positive_rate must be between'):
+            BloomFilter(false_positive_rate=0.0)
+
+    def test_invalid_fp_rate_one(self):
+        with pytest.raises(ValueError, match='false_positive_rate must be between'):
+            BloomFilter(false_positive_rate=1.0)
+
+    def test_invalid_fp_rate_negative(self):
+        with pytest.raises(ValueError, match='false_positive_rate must be between'):
+            BloomFilter(false_positive_rate=-0.1)
+
+    def test_repr(self):
+        bf = BloomFilter(expected_items=100, false_positive_rate=0.01)
+        r = repr(bf)
+        assert 'BloomFilter' in r
+        assert 'size=' in r
+        assert 'hashes=' in r
+        assert 'count=' in r
+
+
+# ---------------------------------------------------------------------------
+# Add and test operations
+# ---------------------------------------------------------------------------
+
+class TestBloomFilterAddAndTest:
+    def test_add_and_test_single_item(self):
+        bf = BloomFilter(expected_items=100)
+        bf.add('hello')
+        assert bf.test('hello') is True
+
+    def test_add_and_test_multiple_items(self):
+        bf = BloomFilter(expected_items=1000)
+        items = [str(i) for i in range(100)]
+        for item in items:
+            bf.add(item)
+
+        # All inserted items MUST be found (zero false negatives)
+        for item in items:
+            assert bf.test(item) is True
+
+    def test_absent_item_returns_false(self):
+        bf = BloomFilter(expected_items=100)
+        bf.add('exists')
+        assert bf.test('does_not_exist') is False
+
+    def test_empty_filter_returns_false(self):
+        bf = BloomFilter(expected_items=100)
+        assert bf.test('anything') is False
+        assert bf.test('') is False
+        assert bf.test('42') is False
+
+    def test_add_increments_count(self):
+        bf = BloomFilter(expected_items=100)
+        assert bf.count == 0
+        bf.add('a')
+        assert bf.count == 1
+        bf.add('b')
+        assert bf.count == 2
+
+    def test_add_integer_items(self):
+        bf = BloomFilter(expected_items=100)
+        bf.add(42)
+        assert bf.test(42) is True
+        # Integers are converted to string internally
+        assert bf.test('42') is True
+
+    def test_zero_false_negatives(self):
+        """
+        The fundamental property of a Bloom Filter: if test() returns False,
+        the item was NEVER added. We verify this over a large set.
+        """
+        bf = BloomFilter(expected_items=10_000, false_positive_rate=0.01)
+        items = {str(i) for i in range(5000)}
+
+        for item in items:
+            bf.add(item)
+
+        for item in items:
+            assert bf.test(item) is True, \
+                f'False negative detected for item {item}'
+
+
+# ---------------------------------------------------------------------------
+# False positive rate
+# ---------------------------------------------------------------------------
+
+class TestBloomFilterFalsePositiveRate:
+    def test_false_positive_rate_within_bounds(self):
+        """
+        The observed false positive rate should be roughly within
+        3x the configured rate for a sufficiently large sample.
+        """
+        n = 5000
+        fp_rate = 0.01
+        bf = BloomFilter(expected_items=n, false_positive_rate=fp_rate)
+
+        for i in range(n):
+            bf.add(f'item_{i}')
+
+        # Test items that were NOT added
+        false_positives = 0
+        test_count = 10_000
+        for i in range(n, n + test_count):
+            if bf.test(f'item_{i}'):
+                false_positives += 1
+
+        observed_rate = false_positives / test_count
+        assert observed_rate <= fp_rate * 3, \
+            f'Observed FP rate {observed_rate:.4f} exceeds 3x target {fp_rate}'
+
+
+# ---------------------------------------------------------------------------
+# Hash determinism
+# ---------------------------------------------------------------------------
+
+class TestBloomFilterHashDeterminism:
+    def test_same_input_same_positions(self):
+        bf = BloomFilter(expected_items=100)
+        pos1 = bf._get_hash_values('test_item')
+        pos2 = bf._get_hash_values('test_item')
+        assert pos1 == pos2
+
+    def test_different_inputs_different_positions(self):
+        bf = BloomFilter(expected_items=100)
+        pos_a = bf._get_hash_values('alpha')
+        pos_b = bf._get_hash_values('beta')
+        assert pos_a != pos_b
+
+
+# ---------------------------------------------------------------------------
+# Rebuild
+# ---------------------------------------------------------------------------
+
+class TestBloomFilterRebuild:
+    def test_rebuild_clears_old_items(self):
+        bf = BloomFilter(expected_items=100)
+        bf.add('old_item')
+        assert bf.test('old_item') is True
+
+        bf.rebuild(['new_item'])
+        assert bf.test('new_item') is True
+        assert bf.count == 1
+
+    def test_rebuild_with_empty_list(self):
+        bf = BloomFilter(expected_items=100)
+        bf.add('item_1')
+        bf.add('item_2')
+
+        bf.rebuild([])
+        assert bf.count == 0
+        assert bf.test('item_1') is False
+        assert bf.test('item_2') is False
+
+    def test_rebuild_preserves_configuration(self):
+        bf = BloomFilter(expected_items=500, false_positive_rate=0.05)
+        original_size = bf.size
+        original_hashes = bf.num_hashes
+
+        bf.rebuild(['a', 'b', 'c'])
+        assert bf.size == original_size
+        assert bf.num_hashes == original_hashes
+
+
+# ---------------------------------------------------------------------------
+# Serialization (to_dict / from_dict)
+# ---------------------------------------------------------------------------
+
+class TestBloomFilterSerialization:
+    def test_round_trip_preserves_state(self):
+        bf = BloomFilter(expected_items=500, false_positive_rate=0.02)
+        for i in range(100):
+            bf.add(f'doc_{i}')
+
+        data = bf.to_dict()
+        restored = BloomFilter.from_dict(data)
+
+        for i in range(100):
+            assert restored.test(f'doc_{i}') is True
+
+        assert restored.count == bf.count
+        assert restored.size == bf.size
+        assert restored.num_hashes == bf.num_hashes
+
+    def test_to_dict_structure(self):
+        bf = BloomFilter(expected_items=100, false_positive_rate=0.01)
+        bf.add('test')
+        data = bf.to_dict()
+
+        assert 'expected_items' in data
+        assert 'fp_rate' in data
+        assert 'size' in data
+        assert 'num_hashes' in data
+        assert 'bit_array' in data
+        assert 'count' in data
+        assert isinstance(data['bit_array'], list)
+
+    def test_from_dict_empty_filter(self):
+        bf = BloomFilter(expected_items=100)
+        data = bf.to_dict()
+        restored = BloomFilter.from_dict(data)
+
+        assert restored.count == 0
+        assert restored.test('anything') is False
+
+
+# ---------------------------------------------------------------------------
+# Optimal parameter calculations
+# ---------------------------------------------------------------------------
+
+class TestBloomFilterOptimalParameters:
+    def test_larger_n_yields_larger_size(self):
+        small = BloomFilter(expected_items=100, false_positive_rate=0.01)
+        large = BloomFilter(expected_items=10_000, false_positive_rate=0.01)
+        assert large.size > small.size
+
+    def test_lower_fp_rate_yields_larger_size(self):
+        high_fp = BloomFilter(expected_items=1000, false_positive_rate=0.1)
+        low_fp = BloomFilter(expected_items=1000, false_positive_rate=0.001)
+        assert low_fp.size > high_fp.size
+
+    def test_num_hashes_is_positive(self):
+        bf = BloomFilter(expected_items=1, false_positive_rate=0.5)
+        assert bf.num_hashes >= 1

--- a/tests/test_bloom_integration.py
+++ b/tests/test_bloom_integration.py
@@ -1,0 +1,347 @@
+"""
+Integration tests for the Bloom Filter within TinyDB tables.
+
+These tests verify that TinyDB tables behave correctly with the Bloom Filter
+enabled by default, including lazy initialization, insert/get/contains
+short-circuits, remove/truncate rebuilds, and full workflows.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tinydb import TinyDB, where
+from tinydb.storages import MemoryStorage, JSONStorage
+from tinydb.table import Document
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(params=['memory', 'json'])
+def db(request, tmp_path: Path):
+    """
+    TinyDB instance with bloom filter active (the default).
+    Parametrized to test with both MemoryStorage and JSONStorage.
+    """
+    if request.param == 'json':
+        db_ = TinyDB(tmp_path / 'test_bloom.db', storage=JSONStorage)
+    else:
+        db_ = TinyDB(storage=MemoryStorage)
+
+    db_.drop_tables()
+    db_.insert_multiple({'int': 1, 'char': c} for c in 'abc')
+    yield db_
+    db_.close()
+
+
+@pytest.fixture
+def table():
+    """A standalone bloom-enabled table for focused tests."""
+    db_ = TinyDB(storage=MemoryStorage)
+    tbl = db_.table('bloom_test')  # bloom_filter=True by default
+    yield tbl
+    db_.close()
+
+
+# ---------------------------------------------------------------------------
+# Bloom Filter default activation
+# ---------------------------------------------------------------------------
+
+class TestBloomDefault:
+    def test_bloom_enabled_by_default(self):
+        db_ = TinyDB(storage=MemoryStorage)
+        tbl = db_.table('_default')
+        assert tbl._bloom is not None
+        assert tbl._use_bloom is True
+        db_.close()
+
+    def test_bloom_can_be_disabled(self):
+        db_ = TinyDB(storage=MemoryStorage)
+        tbl = db_.table('no_bloom', bloom_filter=False)
+        assert tbl._bloom is None
+        assert tbl._use_bloom is False
+        db_.close()
+
+
+# ---------------------------------------------------------------------------
+# Lazy initialization
+# ---------------------------------------------------------------------------
+
+class TestBloomLazyInit:
+    def test_not_initialized_on_construction(self):
+        db_ = TinyDB(storage=MemoryStorage)
+        tbl = db_.table('lazy')
+        # Filter object exists but hasn't been populated yet
+        assert tbl._bloom is not None
+        assert tbl._bloom_initialized is False
+        db_.close()
+
+    def test_initialized_after_first_read(self):
+        db_ = TinyDB(storage=MemoryStorage)
+        tbl = db_.table('lazy')
+        tbl.insert({'val': 1})
+
+        # Force a _read_table call via all()
+        tbl.all()
+        assert tbl._bloom_initialized is True
+        db_.close()
+
+    def test_initialized_after_get_by_id(self):
+        db_ = TinyDB(storage=MemoryStorage)
+        tbl = db_.table('lazy')
+        doc_id = tbl.insert({'val': 1})
+
+        # get(doc_id=...) calls _read_table, which initializes the bloom
+        tbl.get(doc_id=doc_id)
+        assert tbl._bloom_initialized is True
+        db_.close()
+
+
+# ---------------------------------------------------------------------------
+# Insert updates the Bloom Filter
+# ---------------------------------------------------------------------------
+
+class TestBloomInsert:
+    def test_insert_updates_bloom(self, table):
+        doc_id = table.insert({'name': 'alice'})
+
+        # Trigger lazy init by reading
+        table.all()
+
+        assert table._bloom.test(str(doc_id)) is True
+
+    def test_insert_multiple_updates_bloom(self, table):
+        doc_ids = table.insert_multiple([
+            {'name': 'alice'},
+            {'name': 'bob'},
+            {'name': 'charlie'},
+        ])
+
+        # Trigger lazy init
+        table.all()
+
+        for doc_id in doc_ids:
+            assert table._bloom.test(str(doc_id)) is True
+
+    def test_insert_with_doc_id_updates_bloom(self, table):
+        table.insert(Document({'name': 'alice'}, 42))
+        table.all()
+        assert table._bloom.test('42') is True
+
+
+# ---------------------------------------------------------------------------
+# get() and contains() use Bloom Filter for fast negative lookups
+# ---------------------------------------------------------------------------
+
+class TestBloomGetAndContains:
+    def test_get_nonexistent_doc_id(self, table):
+        table.insert({'name': 'alice'})
+        result = table.get(doc_id=9999)
+        assert result is None
+
+    def test_get_existing_doc_id(self, table):
+        doc_id = table.insert({'name': 'alice'})
+        result = table.get(doc_id=doc_id)
+        assert result is not None
+        assert result['name'] == 'alice'
+
+    def test_contains_nonexistent_doc_id(self, table):
+        table.insert({'name': 'alice'})
+        assert table.contains(doc_id=9999) is False
+
+    def test_contains_existing_doc_id(self, table):
+        doc_id = table.insert({'name': 'alice'})
+        assert table.contains(doc_id=doc_id) is True
+
+    def test_get_multiple_doc_ids(self, table):
+        ids = table.insert_multiple([
+            {'name': 'alice'},
+            {'name': 'bob'},
+        ])
+        docs = table.get(doc_ids=ids)
+        assert len(docs) == 2
+
+    def test_get_by_condition_still_works(self, table):
+        table.insert({'name': 'alice', 'age': 30})
+        table.insert({'name': 'bob', 'age': 25})
+
+        result = table.get(where('name') == 'alice')
+        assert result is not None
+        assert result['name'] == 'alice'
+
+    def test_search_still_works(self, table):
+        table.insert({'name': 'alice', 'age': 30})
+        table.insert({'name': 'bob', 'age': 30})
+        table.insert({'name': 'charlie', 'age': 25})
+
+        results = table.search(where('age') == 30)
+        assert len(results) == 2
+
+
+# ---------------------------------------------------------------------------
+# Remove and truncate rebuild the Bloom Filter
+# ---------------------------------------------------------------------------
+
+class TestBloomRemove:
+    def test_remove_by_doc_id_rebuilds_bloom(self, table):
+        doc_id = table.insert({'name': 'alice'})
+        # Ensure bloom is populated
+        table.all()
+        assert table._bloom.test(str(doc_id)) is True
+
+        table.remove(doc_ids=[doc_id])
+        # After rebuild, the removed ID should no longer be in the filter
+        assert table._bloom.test(str(doc_id)) is False
+
+    def test_remove_by_condition_rebuilds_bloom(self, table):
+        doc_id = table.insert({'name': 'alice'})
+        table.insert({'name': 'bob'})
+
+        table.remove(where('name') == 'alice')
+        assert table.get(doc_id=doc_id) is None
+
+    def test_truncate_clears_bloom(self, table):
+        table.insert_multiple([
+            {'name': 'alice'},
+            {'name': 'bob'},
+            {'name': 'charlie'},
+        ])
+        table.all()  # ensure bloom is initialized
+        assert table._bloom.count > 0
+
+        table.truncate()
+        assert table._bloom.count == 0
+
+
+# ---------------------------------------------------------------------------
+# Update operations
+# ---------------------------------------------------------------------------
+
+class TestBloomUpdate:
+    def test_update_does_not_break_bloom(self, table):
+        doc_id = table.insert({'name': 'alice', 'age': 30})
+        table.update({'age': 31}, where('name') == 'alice')
+
+        # The doc_id should still be found
+        result = table.get(doc_id=doc_id)
+        assert result is not None
+        assert result['age'] == 31
+
+
+# ---------------------------------------------------------------------------
+# Full workflow with both storage backends
+# ---------------------------------------------------------------------------
+
+class TestBloomFullWorkflow:
+    def test_full_workflow(self, db: TinyDB):
+        # Verify initial data from fixture
+        assert len(db) == 3
+
+        # Insert
+        doc_id = db.insert({'int': 2, 'char': 'd'})
+        assert len(db) == 4
+
+        # Get by ID
+        doc = db.get(doc_id=doc_id)
+        assert doc is not None
+        assert doc['char'] == 'd'
+
+        # Get nonexistent ID
+        assert db.get(doc_id=99999) is None
+
+        # Contains
+        assert db.contains(doc_id=doc_id) is True
+        assert db.contains(doc_id=99999) is False
+
+        # Search
+        results = db.search(where('int') == 1)
+        assert len(results) == 3
+
+        # Update
+        db.update({'int': 10}, where('char') == 'a')
+        assert db.get(where('int') == 10)['char'] == 'a'
+
+        # Remove
+        db.remove(where('char') == 'd')
+        assert db.contains(doc_id=doc_id) is False
+
+        # Count
+        assert db.count(where('int') == 1) == 2
+
+    def test_all_returns_all_documents(self, db: TinyDB):
+        docs = db.all()
+        assert len(docs) == 3
+
+    def test_upsert_with_bloom(self, db: TinyDB):
+        # Upsert existing document
+        db.upsert({'int': 1, 'char': 'a', 'extra': True},
+                   where('char') == 'a')
+        doc = db.get(where('char') == 'a')
+        assert doc['extra'] is True
+
+        # Upsert new document
+        db.upsert({'int': 5, 'char': 'z'}, where('char') == 'z')
+        assert db.contains(where('char') == 'z')
+
+
+# ---------------------------------------------------------------------------
+# Bloom filter initialization from existing data
+# ---------------------------------------------------------------------------
+
+class TestBloomInitFromExistingData:
+    def test_bloom_initialized_from_existing_data(self):
+        """
+        When opening a table that already has data, the lazy init should
+        populate the bloom filter with existing doc_ids on first read.
+        """
+        db_ = TinyDB(storage=MemoryStorage)
+
+        # Insert data with default table
+        ids = db_.insert_multiple([
+            {'name': 'alice'},
+            {'name': 'bob'},
+            {'name': 'charlie'},
+        ])
+
+        # Force new table instance by clearing the table cache
+        del db_._tables['_default']
+        tbl = db_.table('_default')
+
+        # Trigger lazy init via a read
+        tbl.all()
+
+        # The bloom filter should know about existing doc_ids
+        for doc_id in ids:
+            assert tbl._bloom.test(str(doc_id)) is True
+
+        # Nonexistent ID should not be found
+        assert tbl._bloom.test('99999') is False
+        db_.close()
+
+    def test_bloom_on_empty_table(self):
+        db_ = TinyDB(storage=MemoryStorage)
+        tbl = db_.table('empty')
+        assert tbl.get(doc_id=1) is None
+        db_.close()
+
+
+# ---------------------------------------------------------------------------
+# Bloom disabled: ensure no behavioral difference
+# ---------------------------------------------------------------------------
+
+class TestBloomDisabled:
+    def test_full_workflow_without_bloom(self, tmp_path: Path):
+        db_ = TinyDB(storage=MemoryStorage)
+        tbl = db_.table('no_bloom', bloom_filter=False)
+
+        doc_id = tbl.insert({'name': 'alice'})
+        assert tbl.get(doc_id=doc_id)['name'] == 'alice'
+        assert tbl.get(doc_id=9999) is None
+        assert tbl.contains(doc_id=doc_id) is True
+        assert tbl.contains(doc_id=9999) is False
+
+        tbl.remove(doc_ids=[doc_id])
+        assert tbl.get(doc_id=doc_id) is None
+        db_.close()

--- a/tinydb/__init__.py
+++ b/tinydb/__init__.py
@@ -27,6 +27,7 @@ Usage example:
 from .queries import Query, where
 from .storages import Storage, JSONStorage
 from .database import TinyDB
+from .bloom_filter import BloomFilter
 from .version import __version__
 
-__all__ = ('TinyDB', 'Storage', 'JSONStorage', 'Query', 'where')
+__all__ = ('TinyDB', 'Storage', 'JSONStorage', 'Query', 'where', 'BloomFilter')

--- a/tinydb/bloom_filter.py
+++ b/tinydb/bloom_filter.py
@@ -21,6 +21,7 @@ False
 
 import hashlib
 import math
+import warnings
 from typing import Any, Dict, Iterable, List
 
 __all__ = ('BloomFilter',)
@@ -126,6 +127,20 @@ class BloomFilter:
             self._bit_array[byte_idx] |= (1 << bit_idx)
 
         self._count += 1
+
+        # Warn once when the number of items exceeds the configured
+        # capacity.  Beyond this point the false positive rate degrades
+        # significantly (e.g. ~73% at 5x, ~99% at 10x).
+        if self._count == self._expected_items + 1:
+            warnings.warn(
+                f'BloomFilter: item count ({self._count}) exceeded '
+                f'expected_items ({self._expected_items}). '
+                f'The false positive rate will be significantly higher '
+                f'than the configured {self._fp_rate:.2%}. '
+                f'Consider recreating the table with a larger '
+                f'bloom_expected_items value.',
+                stacklevel=2,
+            )
 
     def test(self, item: Any) -> bool:
         """

--- a/tinydb/bloom_filter.py
+++ b/tinydb/bloom_filter.py
@@ -1,0 +1,221 @@
+"""
+Bloom Filter implementation for fast negative lookups.
+
+A Bloom Filter is a space-efficient probabilistic data structure that is used
+to test whether an element is a member of a set. False positive matches are
+possible, but false negatives are not: if the filter says an element is not
+present, it is **definitely** not present.
+
+This is used by TinyDB to avoid unnecessary storage reads when looking up
+documents by their ID that do not exist in the database.
+
+Usage example:
+
+>>> bf = BloomFilter(expected_items=1000, false_positive_rate=0.01)
+>>> bf.add('42')
+>>> bf.test('42')
+True
+>>> bf.test('99')
+False
+"""
+
+import hashlib
+import math
+from typing import Any, Dict, Iterable, List
+
+__all__ = ('BloomFilter',)
+
+
+class BloomFilter:
+    """
+    A space-efficient probabilistic data structure for membership testing.
+
+    Guarantees zero false negatives: if :meth:`test` returns ``False``, the
+    element is **definitely** not in the set.
+
+    Uses double hashing (MD5 + SHA-256) to generate ``k`` independent hash
+    positions from two base hash functions, following the technique described
+    by Kirsch & Mitzenmacher (2004).
+
+    :param expected_items: Expected number of items to be stored
+    :param false_positive_rate: Desired false positive probability (0 < p < 1)
+    """
+
+    def __init__(
+        self,
+        expected_items: int = 10_000,
+        false_positive_rate: float = 0.01,
+    ):
+        if expected_items <= 0:
+            raise ValueError('expected_items must be positive')
+
+        if not (0 < false_positive_rate < 1):
+            raise ValueError('false_positive_rate must be between 0 and 1')
+
+        self._expected_items = expected_items
+        self._fp_rate = false_positive_rate
+
+        # Optimal bit array size: m = -(n * ln(p)) / (ln(2))^2
+        self._size = self._optimal_size(expected_items, false_positive_rate)
+
+        # Optimal number of hash functions: k = (m / n) * ln(2)
+        self._num_hashes = self._optimal_hashes(self._size, expected_items)
+
+        self._bit_array = bytearray(math.ceil(self._size / 8))
+        self._count = 0
+
+    def __repr__(self):
+        return (
+            f'<BloomFilter size={self._size}, hashes={self._num_hashes}, '
+            f'count={self._count}, fp_rate={self._fp_rate}>'
+        )
+
+    @staticmethod
+    def _optimal_size(n: int, p: float) -> int:
+        """
+        Calculate the optimal bit array size.
+
+        Formula: m = -(n * ln(p)) / (ln(2))^2
+
+        :param n: Expected number of items
+        :param p: Desired false positive rate
+        :returns: Optimal bit array size
+        """
+        m = -(n * math.log(p)) / (math.log(2) ** 2)
+        return int(math.ceil(m))
+
+    @staticmethod
+    def _optimal_hashes(m: int, n: int) -> int:
+        """
+        Calculate the optimal number of hash functions.
+
+        Formula: k = (m / n) * ln(2)
+
+        :param m: Bit array size
+        :param n: Expected number of items
+        :returns: Optimal number of hash functions
+        """
+        k = (m / n) * math.log(2)
+        return max(1, int(round(k)))
+
+    def _get_hash_values(self, item: str) -> List[int]:
+        """
+        Generate ``k`` hash positions using double hashing.
+
+        Uses the scheme: h_i(x) = (h1(x) + i * h2(x)) mod m
+
+        where h1 is derived from MD5 and h2 from SHA-256.
+
+        :param item: The string representation of the item to hash
+        :returns: A list of ``k`` bit positions
+        """
+        item_bytes = item.encode('utf-8')
+        h1 = int(hashlib.md5(item_bytes).hexdigest(), 16)
+        h2 = int(hashlib.sha256(item_bytes).hexdigest(), 16)
+
+        return [(h1 + i * h2) % self._size for i in range(self._num_hashes)]
+
+    def add(self, item: Any) -> None:
+        """
+        Add an item to the filter.
+
+        :param item: The item to add (will be converted to string)
+        """
+        for pos in self._get_hash_values(str(item)):
+            byte_idx, bit_idx = divmod(pos, 8)
+            self._bit_array[byte_idx] |= (1 << bit_idx)
+
+        self._count += 1
+
+    def test(self, item: Any) -> bool:
+        """
+        Test whether an item **might** be in the set.
+
+        - Returns ``False``: the item is **definitely not** in the set
+        - Returns ``True``: the item is **probably** in the set
+          (subject to the configured false positive rate)
+
+        :param item: The item to test (will be converted to string)
+        :returns: Whether the item might be present
+        """
+        for pos in self._get_hash_values(str(item)):
+            byte_idx, bit_idx = divmod(pos, 8)
+            if not (self._bit_array[byte_idx] & (1 << bit_idx)):
+                return False
+
+        return True
+
+    def rebuild(self, items: Iterable[Any]) -> None:
+        """
+        Clear the filter and rebuild it from a new set of items.
+
+        This is used after remove operations, since standard Bloom Filters
+        do not support element deletion.
+
+        :param items: The items to populate the filter with
+        """
+        self._bit_array = bytearray(math.ceil(self._size / 8))
+        self._count = 0
+
+        for item in items:
+            self.add(item)
+
+    @property
+    def count(self) -> int:
+        """
+        Get the number of items that have been added to the filter.
+
+        .. note::
+
+            This does not account for duplicate additions.
+        """
+        return self._count
+
+    @property
+    def size(self) -> int:
+        """
+        Get the size of the bit array in bits.
+        """
+        return self._size
+
+    @property
+    def num_hashes(self) -> int:
+        """
+        Get the number of hash functions used.
+        """
+        return self._num_hashes
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize the filter state to a dictionary.
+
+        This can be used to persist the filter alongside the database.
+
+        :returns: A dictionary containing the filter state
+        """
+        return {
+            'expected_items': self._expected_items,
+            'fp_rate': self._fp_rate,
+            'size': self._size,
+            'num_hashes': self._num_hashes,
+            'bit_array': list(self._bit_array),
+            'count': self._count,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> 'BloomFilter':
+        """
+        Reconstruct a filter from a serialized dictionary.
+
+        :param data: The dictionary produced by :meth:`to_dict`
+        :returns: A new :class:`BloomFilter` instance
+        """
+        bf = cls.__new__(cls)
+        bf._expected_items = data['expected_items']
+        bf._fp_rate = data['fp_rate']
+        bf._size = data['size']
+        bf._num_hashes = data['num_hashes']
+        bf._bit_array = bytearray(data['bit_array'])
+        bf._count = data['count']
+
+        return bf

--- a/tinydb/table.py
+++ b/tinydb/table.py
@@ -444,15 +444,18 @@ class Table:
         """
         if doc_id is not None:
             # Fast path: use the Bloom Filter to discard nonexistent IDs.
-            # If the filter isn't initialized yet, we fall through to get()
-            # which calls _read_table() and initializes the filter.
+            # If the filter isn't initialized yet, we fall through to
+            # _read_table() which initializes the filter.
             if (self._bloom is not None
                     and self._bloom_initialized
                     and not self._bloom.test(str(doc_id))):
                 return False
 
-            # Documents specified by ID
-            return self.get(doc_id=doc_id) is not None
+            # Instead of delegating to get(doc_id=...) — which would
+            # redundantly check the Bloom Filter a second time — we
+            # perform the lookup directly against the table data.
+            table = self._read_table()
+            return str(doc_id) in table
 
         elif cond is not None:
             # Document specified by condition
@@ -666,22 +669,37 @@ class Table:
             # to return the list of affected document IDs
             removed_ids = list(doc_ids)
 
+            # Capture the remaining keys after removal so the Bloom Filter
+            # can be rebuilt inside the updater — avoiding a second
+            # storage read that _rebuild_bloom_filter() would cause.
+            remaining_keys: List[str] = []
+
             def updater(table: dict):
                 for doc_id in removed_ids:
                     table.pop(doc_id)
 
+                # Collect the surviving keys while the table data is still
+                # available in memory.
+                remaining_keys.extend(str(k) for k in table.keys())
+
             # Perform the remove operation
             self._update_table(updater)
 
-            # Rebuild the Bloom Filter since standard filters don't support
-            # element deletion
+            # Rebuild the Bloom Filter from the keys we already captured,
+            # with zero extra storage I/O.
             if self._bloom is not None:
-                self._rebuild_bloom_filter()
+                self._bloom.rebuild(remaining_keys)
+                self._bloom_initialized = True
 
             return removed_ids
 
         if cond is not None:
             removed_ids = []
+
+            # Capture the remaining keys after removal so the Bloom Filter
+            # can be rebuilt inside the updater — avoiding a second
+            # storage read that _rebuild_bloom_filter() would cause.
+            remaining_keys: List[str] = []
 
             # This updater function will be called with the table data
             # as its first argument. See ``Table._update`` for details on this
@@ -705,13 +723,18 @@ class Table:
                         # Remove document from the table
                         table.pop(doc_id)
 
+                # Collect the surviving keys while the table data is still
+                # available in memory.
+                remaining_keys.extend(str(k) for k in table.keys())
+
             # Perform the remove operation
             self._update_table(updater)
 
-            # Rebuild the Bloom Filter since standard filters don't support
-            # element deletion
+            # Rebuild the Bloom Filter from the keys we already captured,
+            # with zero extra storage I/O.
             if self._bloom is not None:
-                self._rebuild_bloom_filter()
+                self._bloom.rebuild(remaining_keys)
+                self._bloom_initialized = True
 
             return removed_ids
 

--- a/tinydb/table.py
+++ b/tinydb/table.py
@@ -104,7 +104,7 @@ class Table:
         name: str,
         cache_size: int = default_query_cache_capacity,
         persist_empty: bool = False,
-        bloom_filter: bool = False,
+        bloom_filter: bool = True,
         bloom_expected_items: int = 10_000,
         bloom_fp_rate: float = 0.01,
     ):
@@ -119,14 +119,16 @@ class Table:
 
         self._next_id = None
 
-        # Initialize the Bloom Filter for fast negative lookups on doc_ids
+        # Initialize the Bloom Filter for fast negative lookups on doc_ids.
+        # The filter is built lazily on first access to avoid an extra
+        # storage read during table construction.
         self._use_bloom = bloom_filter
+        self._bloom_initialized = False
         if self._use_bloom:
             self._bloom: Optional[BloomFilter] = BloomFilter(
                 expected_items=bloom_expected_items,
                 false_positive_rate=bloom_fp_rate,
             )
-            self._rebuild_bloom_filter()
         else:
             self._bloom = None
 
@@ -194,8 +196,10 @@ class Table:
         # See below for details on ``Table._update``
         self._update_table(updater)
 
-        # Update the Bloom Filter with the new document ID
-        if self._bloom is not None:
+        # Update the Bloom Filter with the new document ID.
+        # If the filter hasn't been initialized yet, the next _read_table()
+        # call will rebuild it from storage (which already includes this ID).
+        if self._bloom is not None and self._bloom_initialized:
             self._bloom.add(str(doc_id))
 
         return doc_id
@@ -242,8 +246,9 @@ class Table:
         # See below for details on ``Table._update``
         self._update_table(updater)
 
-        # Update the Bloom Filter with all new document IDs
-        if self._bloom is not None:
+        # Update the Bloom Filter with all new document IDs.
+        # See insert() for why we check _bloom_initialized.
+        if self._bloom is not None and self._bloom_initialized:
             for doc_id in doc_ids:
                 self._bloom.add(str(doc_id))
 
@@ -367,9 +372,12 @@ class Table:
         table = self._read_table()
 
         if doc_id is not None:
-            # Fast path: use the Bloom Filter to discard nonexistent IDs
-            # without reading from storage
-            if self._bloom is not None and not self._bloom.test(str(doc_id)):
+            # Fast path: use the Bloom Filter to discard nonexistent IDs.
+            # The filter is lazily initialized by _read_table() above,
+            # so it is guaranteed to be ready at this point.
+            if (self._bloom is not None
+                    and self._bloom_initialized
+                    and not self._bloom.test(str(doc_id))):
                 return None
 
             # Retrieve a document specified by its ID
@@ -428,8 +436,12 @@ class Table:
         :param doc_id: the document ID to look for
         """
         if doc_id is not None:
-            # Fast path: use the Bloom Filter to discard nonexistent IDs
-            if self._bloom is not None and not self._bloom.test(str(doc_id)):
+            # Fast path: use the Bloom Filter to discard nonexistent IDs.
+            # If the filter isn't initialized yet, we fall through to get()
+            # which calls _read_table() and initializes the filter.
+            if (self._bloom is not None
+                    and self._bloom_initialized
+                    and not self._bloom.test(str(doc_id))):
                 return False
 
             # Documents specified by ID
@@ -806,6 +818,12 @@ class Table:
             # The table does not exist yet, so it is empty
             return {}
 
+        # Lazily initialize the Bloom Filter from the data we just read,
+        # piggybacking on this storage read with zero extra I/O cost.
+        if self._bloom is not None and not self._bloom_initialized:
+            self._bloom.rebuild(table.keys())
+            self._bloom_initialized = True
+
         return table
 
     def _update_table(self, updater: Callable[[Dict[int, Mapping]], None]):
@@ -871,3 +889,4 @@ class Table:
         if self._bloom is not None:
             table = self._read_table()
             self._bloom.rebuild(table.keys())
+            self._bloom_initialized = True

--- a/tinydb/table.py
+++ b/tinydb/table.py
@@ -369,16 +369,21 @@ class Table:
 
         :returns: the document(s) or ``None``
         """
-        table = self._read_table()
 
         if doc_id is not None:
-            # Fast path: use the Bloom Filter to discard nonexistent IDs.
-            # The filter is lazily initialized by _read_table() above,
-            # so it is guaranteed to be ready at this point.
+            # Fast path: use the Bloom Filter to discard nonexistent IDs
+            # *before* any storage I/O.  When the filter is already
+            # initialized (i.e. after the first _read_table() call) this
+            # avoids the overhead of reading and parsing the storage file
+            # for IDs that are definitely absent.
             if (self._bloom is not None
                     and self._bloom_initialized
                     and not self._bloom.test(str(doc_id))):
                 return None
+
+            # The ID might exist (or the filter is not yet initialised).
+            # We need the actual table data from storage.
+            table = self._read_table()
 
             # Retrieve a document specified by its ID
             raw_doc = table.get(str(doc_id), None)
@@ -390,6 +395,8 @@ class Table:
             return self.document_class(raw_doc, doc_id)
 
         elif doc_ids is not None:
+            table = self._read_table()
+
             # Filter the table by extracting out all those documents which
             # have doc id specified in the doc_id list.
 

--- a/tinydb/table.py
+++ b/tinydb/table.py
@@ -18,6 +18,7 @@ from typing import (
     overload
 )
 
+from .bloom_filter import BloomFilter
 from .queries import QueryLike
 from .storages import Storage
 from .utils import LRUCache
@@ -102,7 +103,10 @@ class Table:
         storage: Storage,
         name: str,
         cache_size: int = default_query_cache_capacity,
-        persist_empty: bool = False
+        persist_empty: bool = False,
+        bloom_filter: bool = False,
+        bloom_expected_items: int = 10_000,
+        bloom_fp_rate: float = 0.01,
     ):
         """
         Create a table instance.
@@ -114,6 +118,18 @@ class Table:
             = self.query_cache_class(capacity=cache_size)
 
         self._next_id = None
+
+        # Initialize the Bloom Filter for fast negative lookups on doc_ids
+        self._use_bloom = bloom_filter
+        if self._use_bloom:
+            self._bloom: Optional[BloomFilter] = BloomFilter(
+                expected_items=bloom_expected_items,
+                false_positive_rate=bloom_fp_rate,
+            )
+            self._rebuild_bloom_filter()
+        else:
+            self._bloom = None
+
         if persist_empty:
             self._update_table(lambda table: table.clear())
 
@@ -178,6 +194,10 @@ class Table:
         # See below for details on ``Table._update``
         self._update_table(updater)
 
+        # Update the Bloom Filter with the new document ID
+        if self._bloom is not None:
+            self._bloom.add(str(doc_id))
+
         return doc_id
 
     def insert_multiple(self, documents: Iterable[Mapping]) -> List[int]:
@@ -221,6 +241,11 @@ class Table:
 
         # See below for details on ``Table._update``
         self._update_table(updater)
+
+        # Update the Bloom Filter with all new document IDs
+        if self._bloom is not None:
+            for doc_id in doc_ids:
+                self._bloom.add(str(doc_id))
 
         return doc_ids
 
@@ -342,6 +367,11 @@ class Table:
         table = self._read_table()
 
         if doc_id is not None:
+            # Fast path: use the Bloom Filter to discard nonexistent IDs
+            # without reading from storage
+            if self._bloom is not None and not self._bloom.test(str(doc_id)):
+                return None
+
             # Retrieve a document specified by its ID
             raw_doc = table.get(str(doc_id), None)
 
@@ -398,6 +428,10 @@ class Table:
         :param doc_id: the document ID to look for
         """
         if doc_id is not None:
+            # Fast path: use the Bloom Filter to discard nonexistent IDs
+            if self._bloom is not None and not self._bloom.test(str(doc_id)):
+                return False
+
             # Documents specified by ID
             return self.get(doc_id=doc_id) is not None
 
@@ -620,6 +654,11 @@ class Table:
             # Perform the remove operation
             self._update_table(updater)
 
+            # Rebuild the Bloom Filter since standard filters don't support
+            # element deletion
+            if self._bloom is not None:
+                self._rebuild_bloom_filter()
+
             return removed_ids
 
         if cond is not None:
@@ -650,6 +689,11 @@ class Table:
             # Perform the remove operation
             self._update_table(updater)
 
+            # Rebuild the Bloom Filter since standard filters don't support
+            # element deletion
+            if self._bloom is not None:
+                self._rebuild_bloom_filter()
+
             return removed_ids
 
         raise RuntimeError('Use truncate() to remove all documents')
@@ -664,6 +708,10 @@ class Table:
 
         # Reset document ID counter
         self._next_id = None
+
+        # Clear the Bloom Filter
+        if self._bloom is not None:
+            self._bloom.rebuild([])
 
     def count(self, cond: QueryLike) -> int:
         """
@@ -811,3 +859,15 @@ class Table:
 
         # Clear the query cache, as the table contents have changed
         self.clear_cache()
+
+    def _rebuild_bloom_filter(self) -> None:
+        """
+        Rebuild the Bloom Filter from the current table contents.
+
+        This is called after operations that may invalidate the filter
+        (e.g. remove, truncate) since standard Bloom Filters do not support
+        element deletion.
+        """
+        if self._bloom is not None:
+            table = self._read_table()
+            self._bloom.rebuild(table.keys())


### PR DESCRIPTION
## What was done

This PR introduces an in-memory Bloom Filter to optimize document lookup by `doc_id` in TinyDB.

By default, TinyDB performs `get(doc_id=...)` and `contains(doc_id=...)` by reading the full document table from storage, resulting in unnecessary I/O for nonexistent IDs. With this change, a Bloom Filter provides a fast probabilistic check that immediately discards IDs that are definitely not present, avoiding redundant storage access.

The Bloom Filter is enabled by default and requires no configuration or API changes.

## Implementation details

- Added a new module `bloom_filter.py` implementing a Bloom Filter with double hashing (MD5 + SHA-256).
- Modified `Table.__init__()` to accept optional parameters: `bloom_filter`, `bloom_expected_items`, and `bloom_fp_rate`.
- Uses lazy initialization: the filter is populated on the first `_read_table()` call, piggybacking on existing storage reads with zero extra I/O.
- Updated:
  - `get()` and `contains()` to skip storage access when the Bloom Filter confirms a `doc_id` is absent.
  - `insert()` and `insert_multiple()` to add new IDs to the filter.
  - `remove()` to rebuild the filter after deletions.
  - `truncate()` to clear the filter.
- No external dependencies were introduced.

## Complexity impact

| Operation | Without Bloom | With Bloom (miss) |
|---|---|---|
| `get(doc_id=N)` / `contains(doc_id=N)` | O(n) storage read | O(k) hash computations |

Where:
- *n* is the number of stored documents
- *k* is the number of hash functions (typically 6-10)

False positive rate is configurable (default: 1%), meaning at most 1% of lookups for absent IDs will still hit storage.

## Tests

Two new test files were added:

**`tests/test_bloom_filter.py`** — 7 classes, 27 tests covering the standalone `BloomFilter` in isolation: constructor validation, `add()`/`test()` correctness, zero-false-negative guarantee, hash determinism, `rebuild()`, serialization round-trips, and optimal parameter sizing.

**`tests/test_bloom_integration.py`** — 9 classes, 27 tests covering `BloomFilter` embedded inside `TinyDB.Table`, parametrized over both `MemoryStorage` and `JSONStorage`: lazy initialization, `insert`/`insert_multiple`, `get(doc_id=...)` and `contains()` short-circuit for absent IDs, `remove()` triggering a filter rebuild, `update()` consistency, full CRUD workflow, re-population on table reopen, and correct behavior when the filter is disabled.

All 260 tests pass with no regressions. Coverage: 95%.

---

## Performance

All benchmarks were executed inside Docker containers to isolate the runtime environment and eliminate host-specific variance from CPU scheduling, OS caching, and library versions.

### Methodology

- 50 total runs per dataset scale; first 10 (warmup) and last 10 (cooldown) discarded; 30 effective runs measured.
- Workload: 100 negative lookups per run — `get` and `contains` called with `doc_id` values guaranteed to be absent from the table.
- Storage: `JSONStorage`.
- Dataset scales: 1,000 / 10,000 / 50,000 documents.
- Timing: `time.perf_counter_ns()` with GC disabled during measurement.

### Results

| Scale | Baseline mean (ms) | Optimized mean (ms) | Improvement |
|---|---|---|---|
| 1k docs | 54.72 ± 1.87 | 1.81 ± 0.16 | **96.69%** |
| 10k docs | 787.03 ± 18.90 | 0.62 ± 0.08 | **99.92%** |
| 50k docs | 12,559.88 ± 1,349.95 | 1.29 ± 0.43 | **99.99%** |

![Bloom Filter benchmark comparison](https://raw.githubusercontent.com/matheusvir/eda-oss-performance/main/analysis/plots/tinydb/tinydb_bloom_filter_comparison.png)

### Analysis

The gain scales dramatically with dataset size, which is the expected behavior for a Bloom Filter. Without the optimization, a negative lookup requires scanning the entire JSON file to confirm absence. With the filter, absence is determined in O(k) hash operations with no storage access.

At 50k documents, the baseline takes ~12.5 seconds per batch of 100 lookups; the optimized path takes ~1.3 ms — a reduction of roughly 9,700x. The standard deviation in optimized runs is also orders of magnitude smaller, indicating consistent and stable latency.

**Note:** as a probabilistic data structure, exact timings will vary across runs and machines. The no-false-negative guarantee is preserved: the filter never hides an existing document. False positives (at most 1% by default) simply fall back to the normal verification path.

### Reproducing the benchmark

The full benchmark infrastructure is available in the research repository at [matheusvir/eda-oss-performance](https://github.com/matheusvir/eda-oss-performance).

Relevant files:

- Dockerfile: [`setup/tinydb/Dockerfile`](https://github.com/matheusvir/eda-oss-performance/blob/main/setup/tinydb/Dockerfile)
- Benchmark script: [`experiments/tinydb/benchmark_bloom_filter.py`](https://github.com/matheusvir/eda-oss-performance/blob/main/experiments/tinydb/benchmark_bloom_filter.py)
- Runner script: [`experiments/tinydb/run_bloom_filter.sh`](https://github.com/matheusvir/eda-oss-performance/blob/main/experiments/tinydb/run_bloom_filter.sh)

To run:

```bash
# From the root of eda-oss-performance
bash experiments/tinydb/run_bloom_filter.sh
```

This builds the Docker image from `setup/tinydb/Dockerfile`, mounts the repository, and runs the benchmark script inside the container. Results are written to `results/tinydb/result_tinydb_bloom-filter.json`.

---

Feedback on filter sizing, the false positive rate default, and integration with other lookup paths is welcome.

---

Relates to #480 and #544.
