### PR TITLE
docs: document that search() results share structure with the query cache

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -564,6 +564,12 @@ to the ``table(...)`` function:
 .. hint:: You can set ``cache_size`` to ``None`` to make the cache unlimited in
    size. Also, you can set ``cache_size`` to 0 to disable it.
 
+.. hint:: A repeated search with the same query is served from the cache.
+   The returned list is a fresh copy, but the documents inside it are the
+   same objects the cache holds — treat them as read-only. Mutating a
+   returned document (a key or a nested value) corrupts what a later
+   identical search returns.
+
 .. hint:: It's not possible to open the same table multiple times with different
    settings. After the first invocation, all the subsequent calls will return
    the same table with the same settings as the first one.

--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -697,6 +697,30 @@ def test_query_cache():
     assert db.search(query) == [{'name': 'foo', 'value': 42}]
 
 
+def test_query_cache_documents_are_shared_with_cache():
+    """search() returns a fresh list each call, but its documents are the
+    same objects the cache holds (see the docstring): the list itself can
+    be mutated freely, the documents inside it cannot."""
+    db = TinyDB(storage=MemoryStorage)
+    db.insert({'name': 'Alice', 'tags': ['a', 'b']})
+
+    query = where('name') == 'Alice'
+
+    results1 = db.search(query)
+    assert results1 == [{'name': 'Alice', 'tags': ['a', 'b']}]
+
+    # Mutating the returned list itself doesn't touch the cache.
+    results1.append({'name': 'fake'})
+    results2 = db.search(query)
+    assert results2 == [{'name': 'Alice', 'tags': ['a', 'b']}]
+
+    # But a document inside it is the cached object, so mutating a
+    # top-level key or a nested value both reach the cache.
+    results2[0]['tags'].append('c')
+    results3 = db.search(query)
+    assert results3[0]['tags'] == ['a', 'b', 'c']
+
+
 def test_tinydb_is_iterable(db: TinyDB):
     assert [r for r in db] == db.all()
 

--- a/tinydb/table.py
+++ b/tinydb/table.py
@@ -236,6 +236,12 @@ class Table:
         """
         Search for all documents matching a 'where' cond.
 
+        Note: a repeated search with the same ``cond`` is served from an
+        internal cache. The returned list is a fresh copy, but its
+        documents are the same objects held by the cache -- treat them as
+        read-only, since mutating one (a key or a nested value) corrupts
+        what a later identical search returns.
+
         :param cond: the condition to check against
         :returns: list of matching documents
         """


### PR DESCRIPTION
## Update — converted to a docs-only PR

Per discussion below: a deep copy costs 150-4000x on the read hot path, and there's no fix that's both cheap and complete (a shallow top-level copy stops attribute reassignment but not nested mutation). Reverted the code change; the fix is now a docstring note on `Table.search()` plus a test that documents the actual sharing behavior (list is fresh, documents inside it are the cached objects).

## Original problem (#516)

`Table.search` stored and returned shallow copies of the document list, so a returned `Document` is the same object the cache holds. Mutating a key or a nested value in a returned document corrupts what a later identical search returns:

```python
from tinydb import TinyDB, Query
from tinydb.storages import MemoryStorage

db = TinyDB(storage=MemoryStorage)
db.insert({'name': 'Alice', 'tags': ['a', 'b']})

Q = Query()
results = db.search(Q.name == 'Alice')
results[0]['tags'].append('c')          # mutate the returned document

print(db.search(Q.name == 'Alice'))     # prints [{'name': 'Alice', 'tags': ['a', 'b', 'c']}]
```

## Tests

`test_query_cache_documents_are_shared_with_cache` documents the boundary: mutating the returned list is safe, mutating a document inside it is not. 219/219 pass.