### PR TITLE
fix: LRUCache.get() and __getitem__() fail for cached None values

### DIFF
--- a/tinydb/utils.py
+++ b/tinydb/utils.py
@@ -78,9 +78,10 @@ class LRUCache(abc.MutableMapping, Generic[K, V]):
         del self.cache[key]
 
     def __getitem__(self, key) -> V:
-        value = self.get(key)
-        if value is None:
+        if key not in self.cache:
             raise KeyError(key)
+        value = self.cache[key]
+        self.cache.move_to_end(key, last=True)
 
         return value
 
@@ -88,14 +89,12 @@ class LRUCache(abc.MutableMapping, Generic[K, V]):
         return iter(self.cache)
 
     def get(self, key: K, default: Optional[D] = None) -> Optional[Union[V, D]]:
-        value = self.cache.get(key)
+        if key not in self.cache:
+            return default
+        value = self.cache[key]
+        self.cache.move_to_end(key, last=True)
 
-        if value is not None:
-            self.cache.move_to_end(key, last=True)
-
-            return value
-
-        return default
+        return value
 
     def set(self, key: K, value: V):
         if key in self.cache:


### PR DESCRIPTION
## Problem

`LRUCache.get()` and `LRUCache.__getitem__()` both break when `None` is a legitimate cached value.

**`get()` bug:** uses `if value is not None:` to detect cache hits, so if a key maps to `None`, it skips the LRU promotion and returns the `default` instead of the cached `None`.

**`__getitem__()` bug:** calls `self.get(key)` and then checks `if value is None: raise KeyError`, so it raises `KeyError` even when the key exists with value `None`.

```python
cache = LRUCache(capacity=5)
cache['key'] = None

cache.get('key', 'missing')  # Returns 'missing' instead of None
cache['key']                  # Raises KeyError instead of returning None
```

## Root cause

Both methods use the cached value itself as a sentinel to detect cache misses. This is the same class of bug that was fixed in `set()` by PR #597.

## Fix

Replace the value-based checks with `key not in self.cache` membership tests, consistent with how `set()` was already fixed.